### PR TITLE
feat(changelog): detect per-package release baseline in monorepos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,7 @@ The scripts use this type mapping:
 All configurations support these variables:
 - `CHANGELOG_FILE` - Changelog path (default: CHANGELOG.md)
 - `GIT_CHANGELOG_PATH` - Optional. Restrict changelog generation to commits touching this repository-relative path (e.g. `packages/tar-xz`). Useful for monorepo per-package CHANGELOG files. Empty / unset = repository-wide (default).
+- `GIT_CHANGELOG_SINCE` - Optional. Override the `since` baseline for changelog generation (any git ref: SHA, tag, branch). When set, bypasses both the per-package release-commit detection and the `git describe --tags` fallback. Useful for monorepo workspaces with non-standard release commit patterns. Empty / unset = use auto-detection.
 - `GIT_COMMIT_MESSAGE` - Commit message template
 - `GIT_TAG_NAME` - Tag name template
 - `GIT_REQUIRE_BRANCH` - Required branch for releases

--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ Customize behavior with environment variables:
 ### Changelog
 - `CHANGELOG_FILE` - Changelog file path (default: `CHANGELOG.md`)
 - `GIT_CHANGELOG_PATH` - Optional. When set to a repository-relative path (e.g. `packages/tar-xz`), restrict changelog generation to commits touching that path. Useful for monorepo per-package CHANGELOG files. Empty / unset = repository-wide (default).
+- `GIT_CHANGELOG_SINCE` - Optional. Override the `since` baseline for changelog generation (any git ref: SHA, tag, branch). When set, bypasses both the per-package release-commit detection and the `git describe --tags` fallback. Useful for monorepo workspaces with non-standard release commit patterns. Empty / unset = use auto-detection.
 
 ### Git
 - `GIT_COMMIT_MESSAGE` - Commit message template (default: `release: bump v${version}`)

--- a/scripts/populate-unreleased-changelog.ts
+++ b/scripts/populate-unreleased-changelog.ts
@@ -214,6 +214,71 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
 }
 
 /**
+ * Resolve the `since` baseline for changelog generation.
+ *
+ * Priority:
+ * 1. GIT_CHANGELOG_SINCE env var (any git ref — trust the user)
+ * 2. Per-package detection via `chore(<pkg>): release v` commit when GIT_CHANGELOG_PATH is set
+ * 3. Fallback: `git describe --tags --abbrev=0`
+ */
+export function resolveSinceBaseline(deps: PopulateChangelogDeps): string {
+  // 1. Explicit override wins
+  const sinceOverride = deps.getEnv('GIT_CHANGELOG_SINCE');
+  if (sinceOverride && sinceOverride.trim()) {
+    deps.log(`ℹ️  Using GIT_CHANGELOG_SINCE override: ${sinceOverride.trim()}`);
+    return sinceOverride.trim();
+  }
+
+  // 2. Per-package detection: only when running scoped to a subdir
+  const path = deps.getEnv('GIT_CHANGELOG_PATH');
+  if (path && path.trim()) {
+    let pkgName = '';
+    try {
+      const pkgJsonRaw = deps.readFileSync('package.json', 'utf8') as string;
+      const pkgNameFull = (JSON.parse(pkgJsonRaw) as { name?: string }).name;
+      if (pkgNameFull) {
+        pkgName = pkgNameFull.startsWith('@')
+          ? (pkgNameFull.split('/').pop() ?? '')
+          : pkgNameFull;
+      }
+    } catch {
+      // package.json missing or unreadable — skip per-package detection
+    }
+    if (pkgName) {
+      try {
+        const sha = (
+          deps.execSync(
+            `git log --grep="^chore(${pkgName}): release v" -n 1 --pretty=format:"%H"`,
+            { encoding: 'utf8' },
+          ) as string
+        ).trim();
+        if (sha) {
+          deps.log(
+            `ℹ️  Per-package baseline (chore(${pkgName}): release …): ${sha.substring(0, 7)}`,
+          );
+          return sha;
+        }
+      } catch {
+        // fall through to tag fallback
+      }
+    }
+  }
+
+  // 3. Fallback: existing git describe behavior
+  try {
+    const tag = (
+      deps.execSync('git describe --tags --abbrev=0 2>/dev/null', { encoding: 'utf8' }) as string
+    ).trim();
+    deps.log(`ℹ️  Latest tag: ${tag}`);
+    return tag;
+  } catch {
+    deps.log('ℹ️  No tags found, using all commits');
+    return '';
+  }
+}
+
+
+/**
  * Main function to populate changelog with dependency injection
  */
 export function populateChangelog(deps: PopulateChangelogDeps): void {
@@ -221,14 +286,7 @@ export function populateChangelog(deps: PopulateChangelogDeps): void {
 
   deps.log('📝 Populating [Unreleased] section...');
 
-  let latestTag: string;
-  try {
-    latestTag = (deps.execSync('git describe --tags --abbrev=0 2>/dev/null', { encoding: 'utf8' }) as string).trim();
-    deps.log(`ℹ️  Latest tag: ${latestTag}`);
-  } catch {
-    deps.log('ℹ️  No tags found, using all commits');
-    latestTag = '';
-  }
+  const since = resolveSinceBaseline(deps);
 
   const gitChangelogPath = deps.getEnv('GIT_CHANGELOG_PATH');
   let pathFilter = '';
@@ -246,8 +304,8 @@ export function populateChangelog(deps: PopulateChangelogDeps): void {
     pathFilter = ` -- ${gitChangelogPath}`;
   }
 
-  const gitLogCommand = latestTag
-    ? `git log --pretty=format:"%H|%B|||END|||" ${latestTag}..HEAD${pathFilter}`
+  const gitLogCommand = since
+    ? `git log --pretty=format:"%H|%B|||END|||" ${since}..HEAD${pathFilter}`
     : `git log --pretty=format:"%H|%B|||END|||"${pathFilter}`;
 
   let gitOutput: string;

--- a/tests/unit/populate-unreleased-changelog.test.ts
+++ b/tests/unit/populate-unreleased-changelog.test.ts
@@ -6,6 +6,7 @@ import {
   type PopulateChangelogDeps,
   parseCommitsWithMultiplePrefixes,
   populateChangelog,
+  resolveSinceBaseline,
 } from '../../scripts/populate-unreleased-changelog'
 import { ValidationError } from '../../scripts/lib/errors'
 
@@ -466,6 +467,78 @@ describe('populate-unreleased-changelog (with DI)', () => {
         expect(gitLogCall).toBeDefined()
         expect(gitLogCall![0]).not.toContain(' -- ')
       })
+    })
+  })
+
+  describe('resolveSinceBaseline', () => {
+    beforeEach(() => {
+      deps = {
+        execSync: vi.fn(),
+        readFileSync: vi.fn(),
+        writeFileSync: vi.fn(),
+        getEnv: vi.fn(() => undefined),
+        log: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as unknown as PopulateChangelogDeps
+    })
+
+    it('GIT_CHANGELOG_SINCE override wins over everything else', () => {
+      vi.mocked(deps.getEnv).mockImplementation(k =>
+        k === 'GIT_CHANGELOG_SINCE' ? 'abc123def456' : undefined,
+      )
+      const result = resolveSinceBaseline(deps)
+      expect(result).toBe('abc123def456')
+      expect(deps.execSync).not.toHaveBeenCalled()
+    })
+
+    it('per-package detection: uses last chore(<pkg>): release commit when GIT_CHANGELOG_PATH is set', () => {
+      vi.mocked(deps.getEnv).mockImplementation(k =>
+        k === 'GIT_CHANGELOG_PATH' ? 'packages/nxz' : undefined,
+      )
+      vi.mocked(deps.readFileSync).mockReturnValue(JSON.stringify({ name: '@org/nxz-cli' }))
+      vi.mocked(deps.execSync).mockReturnValue(
+        'ecff028aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n',
+      )
+      const result = resolveSinceBaseline(deps)
+      expect(result).toBe('ecff028aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')
+      expect(vi.mocked(deps.execSync).mock.calls[0][0]).toMatch(
+        /--grep="\^chore\(nxz-cli\): release v"/,
+      )
+    })
+
+    it('per-package detection: falls back to tag when no prior release commit found', () => {
+      vi.mocked(deps.getEnv).mockImplementation(k =>
+        k === 'GIT_CHANGELOG_PATH' ? 'packages/nxz' : undefined,
+      )
+      vi.mocked(deps.readFileSync).mockReturnValue(JSON.stringify({ name: 'nxz-cli' }))
+      vi.mocked(deps.execSync)
+        .mockReturnValueOnce('') // git log --grep returns empty
+        .mockReturnValueOnce('v1.2.3\n') // git describe returns tag
+      const result = resolveSinceBaseline(deps)
+      expect(result).toBe('v1.2.3')
+    })
+
+    it('no GIT_CHANGELOG_PATH: per-package detection NOT attempted, single-package behavior preserved', () => {
+      vi.mocked(deps.getEnv).mockReturnValue(undefined)
+      vi.mocked(deps.execSync).mockReturnValue('v1.0.0\n')
+      const result = resolveSinceBaseline(deps)
+      expect(result).toBe('v1.0.0')
+      // Only ONE execSync call (git describe), NOT two
+      expect(vi.mocked(deps.execSync)).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(deps.execSync).mock.calls[0][0]).toContain('git describe')
+    })
+
+    it('package.json missing: skip per-package detection, fall through to tag', () => {
+      vi.mocked(deps.getEnv).mockImplementation(k =>
+        k === 'GIT_CHANGELOG_PATH' ? '.' : undefined,
+      )
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      vi.mocked(deps.execSync).mockReturnValue('v0.1.0\n')
+      const result = resolveSinceBaseline(deps)
+      expect(result).toBe('v0.1.0')
     })
   })
 })


### PR DESCRIPTION
## Summary

Adds `resolveSinceBaseline()` to `populate-unreleased-changelog.ts` so
monorepo workspaces can release individual packages without their CHANGELOG
re-printing commits already shipped in prior per-package releases.

Resolver order:
- `GIT_CHANGELOG_SINCE` env var override (any git ref — escape hatch for
  projects whose release commits do not follow `chore(<pkg>): release v*`)
- Per-package detection: when `GIT_CHANGELOG_PATH` is set, reads
  `package.json` `.name` (strips `@scope/` prefix), runs
  `git log --grep="^chore(<pkg>): release v" -n 1 --pretty=format:"%H"` and
  uses the SHA as the `since` baseline if found
- Falls back to `git describe --tags` (existing single-package behavior)

Empirical context (from issue #21): when releasing `nxz-cli@6.1.0` in
`oorabona/node-liblzma` on 2026-04-30, the populate script picked up four
commits since the last GPG-signed root tag (`v5.0.0`), only one of which
was the actual `nxz-cli` feature; the other three were already shipped in
prior per-package releases or unrelated to the package. The new resolver
detects `chore(nxz-cli): release v*` (e.g. `ecff028`) as the correct
baseline.

## Test plan

- [x] `pnpm test` — 369/369 (5 new unit tests for `resolveSinceBaseline`)
- [x] `pnpm test:e2e` — 8/8 (no regression)
- [x] `pnpm build` — clean
- [ ] CI green on this PR
- [ ] Cross-checked manually against `node-liblzma` release flow

Closes #21