### PR TITLE
fix(workflow): use prerelease identifier as npm dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,17 +128,19 @@ jobs:
           PUBLISHING="$(node -p 'require("./package.json").version')"
           PKG="$(node -p 'require("./package.json").name')"
 
+          # Strip semver '+build' metadata before any prerelease detection.
+          # Without this, 1.0.0+build-foo (no prerelease, but '-' in metadata)
+          # would falsely match the prerelease branch.
+          PUBLISHING_NO_BUILD="${PUBLISHING%%+*}"
+
           if [ -n "${{ inputs.dist_tag }}" ]; then
             TAG="${{ inputs.dist_tag }}"
             REASON="explicit input"
-          elif [[ "$PUBLISHING" == *-* ]]; then
+          elif [[ "$PUBLISHING_NO_BUILD" == *-* ]]; then
             # Pre-release (semver '-' indicator): use the prerelease identifier as
             # the dist-tag so 'latest' is never demoted to a beta/rc/alpha.
             # 1.0.0-beta.1 -> beta, 2.0.0-rc.2 -> rc, 1.5.0-alpha.5 -> alpha.
             # Users opt in via 'npm install <pkg>@beta' / '@rc' / '@alpha' etc.
-            # Strip semver '+build' metadata first so 1.0.0-alpha+001 -> alpha
-            # (npm dist-tag rejects names containing '+').
-            PUBLISHING_NO_BUILD="${PUBLISHING%%+*}"
             PRERELEASE_ID="${PUBLISHING_NO_BUILD#*-}"
             PRERELEASE_ID="${PRERELEASE_ID%%.*}"
             TAG="$PRERELEASE_ID"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,6 +131,15 @@ jobs:
           if [ -n "${{ inputs.dist_tag }}" ]; then
             TAG="${{ inputs.dist_tag }}"
             REASON="explicit input"
+          elif [[ "$PUBLISHING" == *-* ]]; then
+            # Pre-release (semver '-' indicator): use the prerelease identifier as
+            # the dist-tag so 'latest' is never demoted to a beta/rc/alpha.
+            # 1.0.0-beta.1 -> beta, 2.0.0-rc.2 -> rc, 1.5.0-alpha.5 -> alpha.
+            # Users opt in via 'npm install <pkg>@beta' / '@rc' / '@alpha' etc.
+            PRERELEASE_ID="${PUBLISHING#*-}"
+            PRERELEASE_ID="${PRERELEASE_ID%%.*}"
+            TAG="$PRERELEASE_ID"
+            REASON="pre-release ($PUBLISHING) - using $PRERELEASE_ID, latest unchanged"
           else
             CURRENT_LATEST="$(npm view "${PKG}" version 2>/dev/null || true)"
             if [ -z "$CURRENT_LATEST" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,7 +136,10 @@ jobs:
             # the dist-tag so 'latest' is never demoted to a beta/rc/alpha.
             # 1.0.0-beta.1 -> beta, 2.0.0-rc.2 -> rc, 1.5.0-alpha.5 -> alpha.
             # Users opt in via 'npm install <pkg>@beta' / '@rc' / '@alpha' etc.
-            PRERELEASE_ID="${PUBLISHING#*-}"
+            # Strip semver '+build' metadata first so 1.0.0-alpha+001 -> alpha
+            # (npm dist-tag rejects names containing '+').
+            PUBLISHING_NO_BUILD="${PUBLISHING%%+*}"
+            PRERELEASE_ID="${PUBLISHING_NO_BUILD#*-}"
             PRERELEASE_ID="${PRERELEASE_ID%%.*}"
             TAG="$PRERELEASE_ID"
             REASON="pre-release ($PUBLISHING) - using $PRERELEASE_ID, latest unchanged"


### PR DESCRIPTION
## Summary

Pre-release versions like `1.0.0-beta.1` were tagged as `latest` on the npm registry because `sort -V` places them after stable versions (`1.x > 0.x`). Shipping any preRelease would demote `latest` from the current stable release to a beta — the opposite of npm conventions where users opt in to pre-releases via `npm install <pkg>@beta` / `@rc` / `@alpha`.

## Fix

New branch in `publish.yml` smart dist-tag selection (between explicit input and current-latest comparison): when the publishing version contains a semver `-` indicator, extract the prerelease identifier and use it as the npm dist-tag.

```
1.0.0-beta.1   → beta
2.0.0-rc.2     → rc
1.5.0-alpha.5  → alpha
0.13.1         → existing stable path (latest if newer)
```

`latest` stays untouched on every pre-release ship.

## Test plan

- [x] Local bash logic verified for `1.0.0-beta.1`, `2.0.0-rc.2`, `1.5.0-alpha.5`, `0.13.1` — all assign expected tags.
- [x] Stable path unchanged — falls through to existing newer-than-current-latest comparison.
- [ ] CI: existing publish workflow path validated by next stable ship (this PR ships as v0.13.1 patch using the unmodified stable branch).
- [ ] First pre-release using the new branch: v1.0.0-beta.1 (next).

## Why ship as patch

Bug-fix on infrastructure correctness, no behavior change for stable releases. Unblocks the v1.0.0-beta.X / rc.X cycle planned in the v1.0 staging plan.
