### PR TITLE
refactor(workflows): migrate ci/hotfix/republish to npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: '24'  # npm >= 11.5.1 ships with Node 24, required for OIDC trusted publishing
+
 jobs:
   build-dist:
     uses: ./.github/workflows/build-dist.yml
@@ -44,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -91,7 +94,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -168,13 +171,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure npm authentication
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'  # Required for npm OIDC trusted publishing
 
       - name: Configure Git
         run: |
@@ -208,10 +207,10 @@ jobs:
       - name: Run release and publish
         run: pnpm release-it-preset default --ci --increment ${{ inputs.increment }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_PUBLISH: 'true'      # ✅ Publish to npm with provenance
+          NPM_PUBLISH: 'true'      # ✅ Publish to npm via OIDC trusted publishing
           GITHUB_RELEASE: 'true'   # ✅ Create GitHub Release
+          NPM_SKIP_CHECKS: 'true'  # npm whoami has no static identity under OIDC
 
       - name: Display release and publish info
         run: |

--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -25,6 +25,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  NODE_VERSION: '24'  # npm >= 11.5.1 ships with Node 24, required for OIDC trusted publishing
+
 jobs:
   validate:
     name: Validate
@@ -42,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -73,13 +76,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure npm authentication
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'  # Required for npm OIDC trusted publishing
 
       - name: Configure Git
         run: |
@@ -109,10 +108,10 @@ jobs:
             node bin/cli.js hotfix --ci --increment ${{ inputs.increment }}
           fi
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_PUBLISH: 'true'      # ✅ Publish to npm with provenance
+          NPM_PUBLISH: 'true'      # ✅ Publish to npm via OIDC trusted publishing
           GITHUB_RELEASE: 'true'   # ✅ Create GitHub Release
+          NPM_SKIP_CHECKS: 'true'  # npm whoami has no static identity under OIDC
 
       - name: Display hotfix release and publish info
         if: inputs.dry_run == false

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -16,6 +16,9 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  NODE_VERSION: '24'  # npm >= 11.5.1 ships with Node 24, required for OIDC trusted publishing
+
 concurrency:
   group: republish-${{ inputs.version }}
   cancel-in-progress: false
@@ -104,7 +107,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -131,13 +134,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-
-      - name: Configure npm authentication
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          registry-url: 'https://registry.npmjs.org'  # Required for npm OIDC trusted publishing
 
       - name: Configure Git
         run: |
@@ -153,13 +152,57 @@ jobs:
           name: ${{ needs.build-dist.outputs.artifact_name }}
           path: dist
 
+      # Decide which npm dist-tag to set. When republishing an older version
+      # we must NOT overwrite `latest`; we use a version-named dist-tag instead
+      # (e.g. `v0.10.0`). This mirrors the same logic in publish.yml.
+      - name: Determine npm dist-tag
+        id: dist_tag
+        run: |
+          PUBLISHING="${{ inputs.version }}"
+          PKG="$(node -p 'require("./package.json").name')"
+
+          # Strip semver '+build' metadata before any prerelease detection.
+          # Without this, 1.0.0+build-foo (no prerelease, but '-' in metadata)
+          # would falsely match the prerelease branch.
+          PUBLISHING_NO_BUILD="${PUBLISHING%%+*}"
+
+          if [[ "$PUBLISHING_NO_BUILD" == *-* ]]; then
+            # Pre-release (semver '-' indicator): use the prerelease identifier as
+            # the dist-tag so 'latest' is never demoted to a beta/rc/alpha.
+            # 1.0.0-beta.1 -> beta, 2.0.0-rc.2 -> rc, 1.5.0-alpha.5 -> alpha.
+            PRERELEASE_ID="${PUBLISHING_NO_BUILD#*-}"
+            PRERELEASE_ID="${PRERELEASE_ID%%.*}"
+            TAG="$PRERELEASE_ID"
+            REASON="pre-release ($PUBLISHING) - using $PRERELEASE_ID, latest unchanged"
+          else
+            CURRENT_LATEST="$(npm view "${PKG}" version 2>/dev/null || true)"
+            if [ -z "$CURRENT_LATEST" ]; then
+              TAG="latest"
+              REASON="first publish"
+            elif [ "$(printf '%s\n%s\n' "$PUBLISHING" "$CURRENT_LATEST" | sort -V | tail -1)" = "$PUBLISHING" ] \
+                 && [ "$PUBLISHING" != "$CURRENT_LATEST" ]; then
+              TAG="latest"
+              REASON="newer than current latest ($CURRENT_LATEST)"
+            elif [ "$PUBLISHING" = "$CURRENT_LATEST" ]; then
+              TAG="latest"
+              REASON="same as current latest (idempotent)"
+            else
+              TAG="v$PUBLISHING"
+              REASON="older than current latest ($CURRENT_LATEST) — using version-named tag"
+            fi
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "📌 Republishing ${PKG}@${PUBLISHING} with --tag ${TAG} (${REASON})"
+
       - name: Republish with release-it-preset
         run: pnpm release-it-preset republish --ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_PUBLISH: 'true'
           GITHUB_RELEASE: 'true'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_SKIP_CHECKS: 'true'  # npm whoami has no static identity under OIDC
+          NPM_TAG: ${{ steps.dist_tag.outputs.tag }}
 
       - name: Create audit trail
         run: |

--- a/.github/workflows/republish.yml
+++ b/.github/workflows/republish.yml
@@ -164,6 +164,10 @@ jobs:
           # Strip semver '+build' metadata before any prerelease detection.
           # Without this, 1.0.0+build-foo (no prerelease, but '-' in metadata)
           # would falsely match the prerelease branch.
+          # NOTE: defense-in-depth — the pre-flight regex at line 44 currently
+          # rejects '+' entirely, so this branch is unreachable today via
+          # workflow_dispatch. Kept for byte-parity with publish.yml (where the
+          # version comes from package.json and may legitimately carry +build).
           PUBLISHING_NO_BUILD="${PUBLISHING%%+*}"
 
           if [[ "$PUBLISHING_NO_BUILD" == *-* ]]; then
@@ -200,9 +204,9 @@ jobs:
         env:
           NPM_PUBLISH: 'true'
           GITHUB_RELEASE: 'true'
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_SKIP_CHECKS: 'true'  # npm whoami has no static identity under OIDC
           NPM_TAG: ${{ steps.dist_tag.outputs.tag }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create audit trail
         run: |


### PR DESCRIPTION
## Summary

Migrate the three remaining publish-capable workflows (`ci.yml`, `hotfix.yml`, `republish.yml`) from legacy `NPM_TOKEN` to npm OIDC trusted publishing. Mirror the smart dist-tag selection logic (including the v0.13.1 pre-release branch) into `republish.yml` so republishing an older stable never demotes the registry `latest`.

## Findings addressed (from GHA audit, 2026-04-30)

- **F-AUD-1 critical** in `ci.yml` (lines 174-177), `hotfix.yml` (79-82), `republish.yml` (137-140): legacy `npm config set //registry.../:_authToken $NPM_TOKEN` despite each having `id-token: write` already. → DELETED.
- **F-AUD-2 minor** in same files: missing `NPM_SKIP_CHECKS=true` in publish env. → ADDED.
- **F-AUD missing in `republish.yml`**: no smart dist-tag logic. → ADDED, mirrored from `publish.yml` post-v0.13.1 (incl. pre-release identifier extraction + build metadata strip).
- **Node version drift**: `publish.yml=24`, others=20. → STANDARDIZED to 24 via `NODE_VERSION` env (npm ≥ 11.5.1 mandatory for OIDC handshake).

## Why ship as v0.14.0 (minor)

`republish.yml` and `hotfix.yml` are workflow_dispatch-only emergency paths; `ci.yml`'s release job is rarely-used. The change is behavior-preserving for stable-version flows but adds new dist-tag selection branches in `republish.yml`. Fits a minor bump rather than a patch (changes the auth flow + Node runtime version).

## Verification

- Bash trace for `republish.yml` dist-tag step on 3 inputs (current latest=0.13.1):
  - `1.0.0-beta.1` → `TAG=beta` (pre-release branch)
  - `0.11.0` (stable-older) → `TAG=v0.11.0` (avoids demoting latest)
  - `0.14.0` (stable-newer) → `TAG=latest`
- `grep -rn "NPM_TOKEN\|_authToken" .github/workflows/` returns ZERO real auth uses (only audit.yml comments + ci.yml `validate` CLI test harness with `NPM_TOKEN=dummy-ci-token`).
- 374 unit tests green, `pnpm exec tsc --noEmit` exit 0.

## Test plan

- [x] Local bash trace 3 inputs
- [x] Tests + tsc + build green
- [ ] CI: workflow YAML syntax validated by GitHub on push
- [ ] Post-merge: invoke `republish.yml` with a stable-older version (e.g., dry-run on `0.12.0` if needed) to verify dist-tag selection in production
- [ ] Post-merge: verify `NPM_TOKEN` repository secret can be deleted from settings (no longer referenced)

## Follow-ups (NOT in this PR)

- Add `actionlint` to CI (audit F-AUD-4)
- Add bash unit tests for the dist-tag selection (audit F-AUD-5; opus + codex review of #28 both flagged)
- Consider deleting `NPM_TOKEN` repository secret after this lands
- 6 Dependabot vulns on main (1 critical / 3 high / 2 moderate) — separate triage
