### PR TITLE
feat: v0.15.0 — doctor command + configurable commit-type map + monorepo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -701,6 +701,30 @@ Customize behavior with environment variables:
 - `CHANGELOG_FILE` - Changelog file path (default: `CHANGELOG.md`)
 - `GIT_CHANGELOG_PATH` - Optional. When set to a repository-relative path (e.g. `packages/tar-xz`), restrict changelog generation to commits touching that path. Useful for monorepo per-package CHANGELOG files. Empty / unset = repository-wide (default).
 - `GIT_CHANGELOG_SINCE` - Optional. Override the `since` baseline for changelog generation (any git ref: SHA, tag, branch). When set, bypasses both the per-package release-commit detection and the `git describe --tags` fallback. Useful for monorepo workspaces with non-standard release commit patterns. Empty / unset = use auto-detection.
+- `CHANGELOG_TYPE_MAP` - Optional. JSON string mapping commit types to CHANGELOG section headings. Merged on top of `.changelog-types.json` (if present) and the built-in defaults. Use `false` as a value to suppress a type entirely. Example: `CHANGELOG_TYPE_MAP='{"ops":"### Operations","deps":"### Dependencies"}'`.
+
+### Custom type map (`.changelog-types.json`)
+
+Create a `.changelog-types.json` file in your project root to override or extend the built-in commit-type → section mapping at the project level. The file is merged on top of the built-in defaults; individual keys can be overridden without touching the rest.
+
+**Resolution order** (highest priority wins):
+1. `CHANGELOG_TYPE_MAP` env var (runtime override, e.g. in CI)
+2. `.changelog-types.json` project file
+3. Built-in defaults
+
+**Example `.changelog-types.json`:**
+```json
+{
+  "deps": "### Dependencies",
+  "ops": "### Operations",
+  "ci": false
+}
+```
+- String values must be a valid `### Section Heading`.
+- `false` suppresses the type (no CHANGELOG entry emitted).
+- Malformed JSON or invalid values → warning logged, layer ignored, lower-priority map used.
+
+**BREAKING CHANGE: footer parsing** (Conventional Commits 1.0.0 §6): `BREAKING CHANGE:` is recognised as a footer only when it appears after a blank-line separator from the preceding paragraph. Mid-body occurrences without the blank line do not promote the commit to breaking. Multiple `BREAKING CHANGE:` lines in the same footer paragraph each emit a separate entry under `### ⚠️ BREAKING CHANGES`.
 
 ### Git
 - `GIT_COMMIT_MESSAGE` - Commit message template (default: `release: bump v${version}`)

--- a/README.md
+++ b/README.md
@@ -556,6 +556,45 @@ pnpm release-it-preset check
 
 Useful for debugging release issues.
 
+#### `doctor` - Release Readiness Diagnostic
+
+Runs a structured checklist across four categories and outputs a readiness score:
+
+```bash
+pnpm release-it-preset doctor
+pnpm release-it-preset doctor --json
+```
+
+**What it checks:**
+
+| Category | Checks |
+|----------|--------|
+| Environment | Known env vars, source (env / default / unset), publish-mode consistency |
+| Repository | Git repo presence, branch vs `GIT_REQUIRE_BRANCH`, latest tag, commit count, dirty WD, upstream tracking, remote URL |
+| Configuration | `CHANGELOG.md` exists + Keep a Changelog format + `[Unreleased]` content, `.release-it.json` parseable + `extends` field, `package.json` valid semver version |
+| Readiness Summary | `PASS`/`WARN`/`FAIL` counts, score `N/M checks passing`, status (`READY`/`WARNINGS`/`BLOCKED`), actionable recommendations |
+
+**Exit codes:**
+- `0` — status is `READY` or `WARNINGS`
+- `1` — status is `BLOCKED` (at least one `FAIL`)
+
+**`--json` output shape:**
+```json
+{
+  "environment": { "checks": [...], "vars": [...], "status": "PASS" },
+  "repository":  { "checks": [...], "status": "WARN" },
+  "configuration": { "checks": [...], "status": "PASS" },
+  "summary": {
+    "pass": 10, "warn": 2, "fail": 0, "total": 12,
+    "score": "10/12 checks passing",
+    "status": "WARNINGS",
+    "recommendations": ["Review 2 warning(s) before releasing"]
+  }
+}
+```
+
+Use `doctor` as a pre-release sanity check, and `check` for the full verbose configuration dump.
+
 #### `check-pr` - Pull Request Hygiene
 
 Evaluates PR readiness by analysing commits and changelog changes. Designed for CI usage but safe locally when the required environment variables are set (`PR_BASE_REF`, `PR_HEAD_REF`).

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -232,7 +232,7 @@ function handleUtilityCommand(commandName, args) {
     const runner = useCompiled ? 'node' : 'tsx';
     const target = useCompiled ? compiledPath : sourcePath;
     if (!useCompiled) {
-      console.log('ℹ️  Compiled script not found, falling back to tsx source execution (dev mode).');
+      console.error('ℹ️  Compiled script not found, falling back to tsx source execution (dev mode).');
     }
 
     const child = spawn(runner, [target, ...args], {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -48,6 +48,7 @@ const UTILITY_COMMANDS = {
   update: 'populate-unreleased-changelog',
   validate: 'validate-release',
   check: 'check-config',
+  doctor: 'doctor',
   'check-pr': 'check-pr-status',
   'retry-publish-preflight': 'retry-publish',
 };
@@ -77,6 +78,7 @@ Utility Commands:
   update                 Update [Unreleased] section from commits
   validate [--allow-dirty]  Validate project is ready for release
   check                  Display configuration and project status
+  doctor                 Run diagnostic checklist and show readiness score
   check-pr               Evaluate PR hygiene (branch diff, changelog status, conventions)
   retry-publish-preflight  Run retry publish safety checks without executing release
 
@@ -222,7 +224,7 @@ function handleUtilityCommand(commandName, args) {
   const compiledPath = join(__dirname, '..', 'dist', 'scripts', `${base}.js`);
   const sourcePath = join(__dirname, '..', 'scripts', `${base}.ts`);
 
-  console.log(`🔧 Running utility command: ${commandName}\n`);
+  console.error(`🔧 Running utility command: ${commandName}\n`);
 
   // Prefer compiled script; fallback to tsx source if not built yet (developer convenience)
   import('node:fs').then(fs => {

--- a/examples/monorepo-workflow.md
+++ b/examples/monorepo-workflow.md
@@ -2,6 +2,8 @@
 
 This guide shows how to use `@oorabona/release-it-preset` in monorepo projects with shared configurations.
 
+> **Looking for a runnable example?** See [`examples/monorepo/`](./monorepo/) — a minimal pnpm workspace with two packages, demonstrating `GIT_CHANGELOG_PATH` per-package CHANGELOG generation end-to-end. This guide focuses on config composition and `extends` patterns; the runnable example focuses on the changelog filtering itself.
+
 ## Overview
 
 Monorepos often need to:

--- a/examples/monorepo/.gitignore
+++ b/examples/monorepo/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+.DS_Store

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -38,15 +38,20 @@ the `devDependencies` path).
 
 ### 1. Make a baseline commit (so there's a "since" anchor)
 
+> ⚠️ **If you're exploring this example inside a clone of `release-it-preset`,
+> do NOT tag the parent repo.** Either copy this folder to a fresh location
+> first (`cp -r examples/monorepo /tmp/my-monorepo-demo && cd /tmp/my-monorepo-demo && git init && git add . && git commit -m 'init'`),
+> or set `GIT_CHANGELOG_SINCE=<sha>` instead of tagging.
+
+If you're in a fresh clone:
+
 ```bash
-git -C ../.. tag --list  # check if there's already a tag
-# If not:
-git -C ../.. tag v0.0.0-monorepo-demo
+git tag v0.0.0-monorepo-demo
 ```
 
 The preset uses `git describe --tags --abbrev=0` as the default `since`
-baseline. If your repo has no tags yet, set `GIT_CHANGELOG_SINCE` explicitly
-to a known SHA.
+baseline. If your repo has no tags yet, set `GIT_CHANGELOG_SINCE=<commit-sha>`
+to override.
 
 ### 2. Make per-package commits
 
@@ -72,9 +77,15 @@ git commit -m "feat(pkg-a): add farewell function"
 
 ### 3. Update pkg-a's CHANGELOG
 
+> ⚠️ Run `release-it-preset update` from the **monorepo root** (this folder),
+> not from inside `packages/pkg-a/`. `GIT_CHANGELOG_PATH` is a `git log -- <path>`
+> pathspec that resolves against the current working directory, and from inside
+> the package directory the path `packages/pkg-a` would not exist.
+
 ```bash
-cd packages/pkg-a
-GIT_CHANGELOG_PATH=packages/pkg-a pnpm release-it-preset update
+# From the monorepo root (examples/monorepo/):
+GIT_CHANGELOG_PATH=packages/pkg-a CHANGELOG_FILE=packages/pkg-a/CHANGELOG.md \
+  pnpm release-it-preset update
 ```
 
 Expected output:
@@ -104,8 +115,9 @@ from pkg-a's CHANGELOG — exactly the per-package isolation we wanted.
 ### 4. Update pkg-b's CHANGELOG
 
 ```bash
-cd ../pkg-b
-GIT_CHANGELOG_PATH=packages/pkg-b pnpm release-it-preset update
+# Still from the monorepo root:
+GIT_CHANGELOG_PATH=packages/pkg-b CHANGELOG_FILE=packages/pkg-b/CHANGELOG.md \
+  pnpm release-it-preset update
 ```
 
 `packages/pkg-b/CHANGELOG.md` now shows only the `fix(pkg-b)` commit:

--- a/examples/monorepo/README.md
+++ b/examples/monorepo/README.md
@@ -1,0 +1,160 @@
+# Monorepo Example — per-package CHANGELOG with release-it-preset
+
+This is a runnable demo of `@oorabona/release-it-preset` driving **per-package
+changelog generation** in a pnpm workspace using the `GIT_CHANGELOG_PATH` env
+var. Walk through it once, then adapt the patterns to your own monorepo.
+
+## What this example demonstrates
+
+Two sibling packages (`@example/pkg-a`, `@example/pkg-b`) live under
+`packages/` in a pnpm workspace. Each has its own `CHANGELOG.md` and
+`.release-it.json` that extends the preset's `default` config. The trick:
+when you run `release-it-preset update` from inside a package directory with
+`GIT_CHANGELOG_PATH=packages/<pkg>` set, the preset filters `git log` to
+commits that touched files under that path. Result: pkg-a's CHANGELOG never
+sees pkg-b commits, and vice versa.
+
+## Prerequisites
+
+- Node.js ≥ 24 (the preset requires npm ≥ 11.5.1 for OIDC; npm 18+ works for
+  this demo since we don't actually publish)
+- pnpm ≥ 10
+- A git repo at the project root (any parent of this folder will do — the
+  example shares its parent's `.git`)
+
+## Setup
+
+```bash
+# From the release-it-preset repo root:
+cd examples/monorepo
+pnpm install
+```
+
+`pnpm install` resolves the workspace and links `@oorabona/release-it-preset`
+from npm (or from the repo if you run this against a local checkout — adjust
+the `devDependencies` path).
+
+## Walkthrough
+
+### 1. Make a baseline commit (so there's a "since" anchor)
+
+```bash
+git -C ../.. tag --list  # check if there's already a tag
+# If not:
+git -C ../.. tag v0.0.0-monorepo-demo
+```
+
+The preset uses `git describe --tags --abbrev=0` as the default `since`
+baseline. If your repo has no tags yet, set `GIT_CHANGELOG_SINCE` explicitly
+to a known SHA.
+
+### 2. Make per-package commits
+
+```bash
+# Add a feature to pkg-a
+echo '// feat: add greet()' >> packages/pkg-a/src/index.js
+git add packages/pkg-a/src/index.js
+git commit -m "feat(pkg-a): add greet function"
+
+# Fix something in pkg-b
+echo '// fix: typo' >> packages/pkg-b/src/index.js
+git add packages/pkg-b/src/index.js
+git commit -m "fix(pkg-b): correct typo in module banner"
+
+# Touch root files only — should NOT appear in either package CHANGELOG
+git commit -m "chore: bump root devdep" --allow-empty
+
+# Another pkg-a feature
+echo '// feat: add farewell()' >> packages/pkg-a/src/index.js
+git add packages/pkg-a/src/index.js
+git commit -m "feat(pkg-a): add farewell function"
+```
+
+### 3. Update pkg-a's CHANGELOG
+
+```bash
+cd packages/pkg-a
+GIT_CHANGELOG_PATH=packages/pkg-a pnpm release-it-preset update
+```
+
+Expected output:
+
+```
+🔧 Running utility command: update
+
+📝 Populating [Unreleased] section...
+ℹ️  Latest tag: v0.0.0-monorepo-demo
+✅ Updated [Unreleased] section with 2 commit(s)
+```
+
+Open `CHANGELOG.md`:
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- add greet function (pkg-a) ([<sha>](...))
+- add farewell function (pkg-a) ([<sha>](...))
+```
+
+Note: the `fix(pkg-b)` and `chore: bump root devdep` commits are **absent**
+from pkg-a's CHANGELOG — exactly the per-package isolation we wanted.
+
+### 4. Update pkg-b's CHANGELOG
+
+```bash
+cd ../pkg-b
+GIT_CHANGELOG_PATH=packages/pkg-b pnpm release-it-preset update
+```
+
+`packages/pkg-b/CHANGELOG.md` now shows only the `fix(pkg-b)` commit:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- correct typo in module banner (pkg-b) ([<sha>](...))
+```
+
+## Variant — `GIT_CHANGELOG_SINCE` for non-standard release commits
+
+If your monorepo doesn't tag, or you want to override the baseline (e.g.
+include commits since a specific feature SHA), set `GIT_CHANGELOG_SINCE`:
+
+```bash
+GIT_CHANGELOG_PATH=packages/pkg-a \
+  GIT_CHANGELOG_SINCE=abc1234 \
+  pnpm release-it-preset update
+```
+
+When `GIT_CHANGELOG_SINCE` is set, it bypasses both per-package release
+detection and the `git describe --tags` fallback.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Commit appears in the wrong package CHANGELOG | `GIT_CHANGELOG_PATH` doesn't match the package directory (or unset → all commits picked up) | Verify the env var matches the package's location relative to repo root |
+| Both packages' CHANGELOGs have all commits | Forgot to set `GIT_CHANGELOG_PATH` | Set it: `GIT_CHANGELOG_PATH=packages/<pkg>` |
+| `update` says no commits since last tag | No git tag exists yet | Run `git tag v0.0.0-init` once, or set `GIT_CHANGELOG_SINCE=<sha>` |
+| `[Unreleased]` is overwritten | The `update` command replaces existing `[Unreleased]` content | Curate manually after `update`, or use `manual-changelog` config to skip auto-generation at release time |
+| Custom commit type lands in wrong section | Default mapping doesn't recognize `deps:` (etc.) | Add a `.changelog-types.json` with `{"deps": "### Dependencies"}` (project-level) or `CHANGELOG_TYPE_MAP` env var (highest priority) |
+
+## Adapting to your monorepo
+
+- Package directory structure can be `packages/`, `apps/`, anything — just match `GIT_CHANGELOG_PATH` to it.
+- Combine with `release-it-preset doctor` (run from inside a package) to verify the env vars + git state are right before releasing.
+- For per-package release commit auto-detection, see the main project README's `GIT_CHANGELOG_PATH` section: when set, the preset auto-detects `chore(<pkg-name>): release v*` commits and uses them as the `since` baseline.
+
+## Files in this example
+
+- `pnpm-workspace.yaml` — declares `packages/*` as the workspace
+- `package.json` — root devdeps (`release-it-preset`, `release-it`)
+- `.gitignore` — excludes `node_modules/`
+- `packages/pkg-a/`, `packages/pkg-b/`:
+  - `package.json` — minimal package metadata
+  - `.release-it.json` — extends the preset's `default` config
+  - `CHANGELOG.md` — Keep a Changelog skeleton with `[Unreleased]`
+  - `src/index.js` — placeholder module

--- a/examples/monorepo/package.json
+++ b/examples/monorepo/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@example/monorepo-root",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Worked example: per-package CHANGELOG with @oorabona/release-it-preset",
+  "type": "module",
+  "scripts": {
+    "demo:update-pkg-a": "GIT_CHANGELOG_PATH=packages/pkg-a release-it-preset update",
+    "demo:update-pkg-b": "GIT_CHANGELOG_PATH=packages/pkg-b release-it-preset update"
+  },
+  "devDependencies": {
+    "@oorabona/release-it-preset": "^0.15.0",
+    "release-it": "^20.0.0"
+  },
+  "packageManager": "pnpm@10.17.1"
+}

--- a/examples/monorepo/packages/pkg-a/.release-it.json
+++ b/examples/monorepo/packages/pkg-a/.release-it.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@oorabona/release-it-preset/config/default"
+}

--- a/examples/monorepo/packages/pkg-a/CHANGELOG.md
+++ b/examples/monorepo/packages/pkg-a/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/examples/monorepo/packages/pkg-a/package.json
+++ b/examples/monorepo/packages/pkg-a/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@example/pkg-a",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "release": "release-it-preset default"
+  }
+}

--- a/examples/monorepo/packages/pkg-a/src/index.js
+++ b/examples/monorepo/packages/pkg-a/src/index.js
@@ -1,0 +1,4 @@
+// @example/pkg-a — minimal placeholder
+export function hello(name = 'world') {
+  return `Hello, ${name}!`;
+}

--- a/examples/monorepo/packages/pkg-b/.release-it.json
+++ b/examples/monorepo/packages/pkg-b/.release-it.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@oorabona/release-it-preset/config/default"
+}

--- a/examples/monorepo/packages/pkg-b/CHANGELOG.md
+++ b/examples/monorepo/packages/pkg-b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/examples/monorepo/packages/pkg-b/package.json
+++ b/examples/monorepo/packages/pkg-b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@example/pkg-b",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.js",
+  "scripts": {
+    "release": "release-it-preset default"
+  }
+}

--- a/examples/monorepo/packages/pkg-b/src/index.js
+++ b/examples/monorepo/packages/pkg-b/src/index.js
@@ -1,0 +1,4 @@
+// @example/pkg-b — minimal placeholder
+export function greet(name = 'world') {
+  return `Greetings, ${name}!`;
+}

--- a/examples/monorepo/pnpm-workspace.yaml
+++ b/examples/monorepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -563,7 +563,7 @@ export function formatJson(report: DoctorReport): string {
 // CLI entry (guarded)
 // ---------------------------------------------------------------------------
 
-if (process.argv[1] && (process.argv[1].endsWith('doctor.js') || process.argv[1].endsWith('doctor.ts'))) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   const isJson = process.argv.includes('--json')
 
   const deps: DoctorDeps = {

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -1,0 +1,585 @@
+#!/usr/bin/env tsx
+/**
+ * Doctor — diagnostic checklist + readiness score for release-it-preset
+ *
+ * Inspects four categories:
+ *   1. Environment  — all known env vars, source (env vs default)
+ *   2. Repository   — git state (branch, tag, dirty WD, upstream)
+ *   3. Configuration — CHANGELOG.md, .release-it.json, package.json
+ *   4. Summary      — READY / WARNINGS / BLOCKED + score
+ *
+ * Usage:
+ *   node dist/scripts/doctor.js
+ *   node dist/scripts/doctor.js --json
+ */
+
+import type { ExecSyncOptions } from 'node:child_process'
+import { execSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { isValidSemver } from './lib/semver-utils.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = 'PASS' | 'WARN' | 'FAIL'
+
+export interface CheckResult {
+  name: string
+  status: CheckStatus
+  value: string
+  detail?: string
+}
+
+export interface EnvVarInfo {
+  name: string
+  value: string | undefined
+  source: 'env' | 'default' | 'unset'
+  defaultValue?: string
+}
+
+export interface EnvironmentSection {
+  checks: CheckResult[]
+  vars: EnvVarInfo[]
+  status: CheckStatus
+}
+
+export interface RepositorySection {
+  checks: CheckResult[]
+  status: CheckStatus
+}
+
+export interface ConfigurationSection {
+  checks: CheckResult[]
+  status: CheckStatus
+}
+
+export interface DoctorSummary {
+  pass: number
+  warn: number
+  fail: number
+  total: number
+  score: string
+  status: 'READY' | 'WARNINGS' | 'BLOCKED'
+  recommendations: string[]
+}
+
+export interface DoctorReport {
+  environment: EnvironmentSection
+  repository: RepositorySection
+  configuration: ConfigurationSection
+  summary: DoctorSummary
+}
+
+export interface DoctorDeps {
+  execSync: (command: string, options?: ExecSyncOptions) => Buffer | string
+  existsSync: typeof existsSync
+  readFileSync: typeof readFileSync
+  getEnv: (key: string) => string | undefined
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function safeExec(command: string, deps: DoctorDeps): string | null {
+  try {
+    return (deps.execSync(command, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }) as string).trim()
+  } catch {
+    return null
+  }
+}
+
+function worstStatus(statuses: CheckStatus[]): CheckStatus {
+  if (statuses.includes('FAIL')) return 'FAIL'
+  if (statuses.includes('WARN')) return 'WARN'
+  return 'PASS'
+}
+
+// ---------------------------------------------------------------------------
+// ENV VAR CATALOG
+// ---------------------------------------------------------------------------
+
+const ENV_VAR_CATALOG: Array<{ name: string; defaultValue?: string }> = [
+  { name: 'CHANGELOG_FILE', defaultValue: 'CHANGELOG.md' },
+  { name: 'GIT_CHANGELOG_PATH' },
+  { name: 'GIT_CHANGELOG_SINCE' },
+  { name: 'GIT_COMMIT_MESSAGE', defaultValue: 'release: bump v${version}' },
+  { name: 'GIT_TAG_NAME', defaultValue: 'v${version}' },
+  { name: 'GIT_REQUIRE_BRANCH', defaultValue: 'main' },
+  { name: 'GIT_REQUIRE_UPSTREAM', defaultValue: 'false' },
+  { name: 'GIT_REQUIRE_CLEAN', defaultValue: 'false' },
+  { name: 'GIT_REMOTE', defaultValue: 'origin' },
+  { name: 'GIT_CHANGELOG_COMMAND' },
+  { name: 'GIT_CHANGELOG_DESCRIBE_COMMAND' },
+  { name: 'GITHUB_RELEASE', defaultValue: 'false' },
+  { name: 'GITHUB_REPOSITORY' },
+  { name: 'NPM_PUBLISH', defaultValue: 'false' },
+  { name: 'NPM_SKIP_CHECKS', defaultValue: 'false' },
+  { name: 'NPM_ACCESS', defaultValue: 'public' },
+  { name: 'NPM_TAG' },
+]
+
+// ---------------------------------------------------------------------------
+// 1. Environment
+// ---------------------------------------------------------------------------
+
+export function collectEnvironment(deps: DoctorDeps): EnvironmentSection {
+  const vars: EnvVarInfo[] = ENV_VAR_CATALOG.map(({ name, defaultValue }) => {
+    const value = deps.getEnv(name)
+    if (value !== undefined) {
+      return { name, value, source: 'env' as const }
+    }
+    if (defaultValue !== undefined) {
+      return { name, value: defaultValue, source: 'default' as const, defaultValue }
+    }
+    return { name, value: undefined, source: 'unset' as const, defaultValue }
+  })
+
+  const checks: CheckResult[] = []
+
+  const githubRelease = deps.getEnv('GITHUB_RELEASE')
+  const githubRepo = deps.getEnv('GITHUB_REPOSITORY')
+  const npmPublish = deps.getEnv('NPM_PUBLISH')
+
+  if (githubRelease === 'true' && !githubRepo) {
+    checks.push({
+      name: 'GITHUB_REPOSITORY set when GITHUB_RELEASE=true',
+      status: 'WARN',
+      value: '<unset>',
+      detail: 'Set GITHUB_REPOSITORY=owner/repo to enable GitHub releases',
+    })
+  } else {
+    checks.push({
+      name: 'GitHub release configuration',
+      status: 'PASS',
+      value: githubRelease === 'true' ? 'enabled' : 'disabled (default)',
+    })
+  }
+
+  if (npmPublish === 'true') {
+    checks.push({
+      name: 'npm publish configuration',
+      status: 'PASS',
+      value: 'enabled (NPM_PUBLISH=true)',
+    })
+  } else {
+    checks.push({
+      name: 'npm publish configuration',
+      status: 'PASS',
+      value: 'disabled (default — safe for local runs)',
+    })
+  }
+
+  return {
+    vars,
+    checks,
+    status: worstStatus(checks.map((c) => c.status)),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Repository
+// ---------------------------------------------------------------------------
+
+export function inspectRepository(deps: DoctorDeps): RepositorySection {
+  const checks: CheckResult[] = []
+
+  const isGitRepo = safeExec('git rev-parse --git-dir', deps) !== null
+  if (!isGitRepo) {
+    checks.push({
+      name: 'Git repository',
+      status: 'FAIL',
+      value: 'not a git repository',
+      detail: 'Run doctor from inside a git repository',
+    })
+    return { checks, status: 'FAIL' }
+  }
+  checks.push({ name: 'Git repository', status: 'PASS', value: 'yes' })
+
+  const branch = safeExec('git rev-parse --abbrev-ref HEAD', deps)
+  const requiredBranch = deps.getEnv('GIT_REQUIRE_BRANCH') ?? 'main'
+  if (!branch) {
+    checks.push({
+      name: 'Current branch',
+      status: 'WARN',
+      value: 'unknown',
+      detail: 'Could not determine current branch',
+    })
+  } else if (requiredBranch && branch !== requiredBranch) {
+    checks.push({
+      name: 'Current branch',
+      status: 'WARN',
+      value: branch,
+      detail: `GIT_REQUIRE_BRANCH is "${requiredBranch}" — release will fail on this branch`,
+    })
+  } else {
+    checks.push({ name: 'Current branch', status: 'PASS', value: branch })
+  }
+
+  const latestTag = safeExec('git describe --tags --abbrev=0', deps)
+  if (!latestTag) {
+    checks.push({
+      name: 'Latest tag',
+      status: 'WARN',
+      value: 'none',
+      detail: 'No tags found — first release scenario',
+    })
+  } else {
+    checks.push({ name: 'Latest tag', status: 'PASS', value: latestTag })
+  }
+
+  let commitCount = 0
+  if (latestTag) {
+    const countStr = safeExec(`git rev-list "${latestTag}"..HEAD --count`, deps)
+    commitCount = countStr ? parseInt(countStr, 10) : 0
+  } else {
+    const countStr = safeExec('git rev-list HEAD --count', deps)
+    commitCount = countStr ? parseInt(countStr, 10) : 0
+  }
+  checks.push({
+    name: 'Commits since last tag',
+    status: 'PASS',
+    value: String(commitCount),
+  })
+
+  const dirtyOutput = safeExec('git status --porcelain', deps)
+  const isDirty = dirtyOutput !== null && dirtyOutput.length > 0
+  if (isDirty) {
+    checks.push({
+      name: 'Working directory clean',
+      status: 'WARN',
+      value: 'dirty',
+      detail: 'Uncommitted changes present — release may fail if GIT_REQUIRE_CLEAN=true',
+    })
+  } else {
+    checks.push({ name: 'Working directory clean', status: 'PASS', value: 'yes' })
+  }
+
+  const upstream = safeExec('git rev-parse --abbrev-ref @{u}', deps)
+  if (!upstream) {
+    checks.push({
+      name: 'Upstream tracking branch',
+      status: 'WARN',
+      value: 'none',
+      detail: 'No upstream set — git push will fail. Run: git push -u origin <branch>',
+    })
+  } else {
+    checks.push({ name: 'Upstream tracking branch', status: 'PASS', value: upstream })
+  }
+
+  const remote = deps.getEnv('GIT_REMOTE') ?? 'origin'
+  const remoteUrl = safeExec(`git config --get remote.${remote}.url`, deps)
+  if (!remoteUrl) {
+    checks.push({
+      name: `Git remote (${remote})`,
+      status: 'WARN',
+      value: 'not configured',
+      detail: `Remote "${remote}" not found. Set GIT_REMOTE or run: git remote add origin <url>`,
+    })
+  } else {
+    checks.push({ name: `Git remote (${remote})`, status: 'PASS', value: remoteUrl })
+  }
+
+  return { checks, status: worstStatus(checks.map((c) => c.status)) }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Configuration
+// ---------------------------------------------------------------------------
+
+export function validateConfiguration(deps: DoctorDeps): ConfigurationSection {
+  const checks: CheckResult[] = []
+  const changelogPath = deps.getEnv('CHANGELOG_FILE') ?? 'CHANGELOG.md'
+
+  if (!deps.existsSync(changelogPath)) {
+    checks.push({
+      name: `${changelogPath} exists`,
+      status: 'FAIL',
+      value: 'missing',
+      detail: `Run: release-it-preset init  OR create ${changelogPath} manually`,
+    })
+  } else {
+    checks.push({ name: `${changelogPath} exists`, status: 'PASS', value: 'yes' })
+
+    const content = deps.readFileSync(changelogPath, 'utf8') as string
+
+    const hasKacHeader = /^# Changelog/m.test(content)
+    if (!hasKacHeader) {
+      checks.push({
+        name: 'Keep a Changelog format',
+        status: 'FAIL',
+        value: 'invalid',
+        detail: 'CHANGELOG.md must start with "# Changelog" (Keep a Changelog format)',
+      })
+    } else {
+      checks.push({ name: 'Keep a Changelog format', status: 'PASS', value: 'valid' })
+    }
+
+    const unreleasedMatch = content.match(/## \[Unreleased\]([\s\S]*?)(?=## \[|$)/)
+    if (!unreleasedMatch) {
+      checks.push({
+        name: '[Unreleased] section',
+        status: 'FAIL',
+        value: 'missing',
+        detail: 'Add "## [Unreleased]" section — run: release-it-preset update',
+      })
+    } else {
+      const unreleasedContent = unreleasedMatch[1].trim()
+      const hasChanges = /^-/m.test(unreleasedContent)
+      if (!unreleasedContent || !hasChanges) {
+        checks.push({
+          name: '[Unreleased] section',
+          status: 'WARN',
+          value: 'empty',
+          detail: 'No entries yet — run: release-it-preset update',
+        })
+      } else {
+        checks.push({ name: '[Unreleased] section', status: 'PASS', value: 'has content' })
+      }
+    }
+  }
+
+  const hasReleaseItJson = deps.existsSync('.release-it.json')
+  if (!hasReleaseItJson) {
+    checks.push({
+      name: '.release-it.json exists',
+      status: 'WARN',
+      value: 'missing',
+      detail: 'Optional but recommended. Run: release-it-preset init',
+    })
+  } else {
+    checks.push({ name: '.release-it.json exists', status: 'PASS', value: 'yes' })
+
+    try {
+      const raw = deps.readFileSync('.release-it.json', 'utf8') as string
+      const config = JSON.parse(raw) as Record<string, unknown>
+      const extendsField = config.extends as string | undefined
+
+      if (!extendsField) {
+        checks.push({
+          name: '.release-it.json extends preset',
+          status: 'WARN',
+          value: 'no extends field',
+          detail: 'Add "extends": "@oorabona/release-it-preset/config/<name>" for CLI auto-detection',
+        })
+      } else if (!/@oorabona\/release-it-preset\/config\/[\w-]+/.test(extendsField)) {
+        checks.push({
+          name: '.release-it.json extends preset',
+          status: 'WARN',
+          value: extendsField,
+          detail: 'extends does not point to @oorabona/release-it-preset/config/<name>',
+        })
+      } else {
+        checks.push({
+          name: '.release-it.json extends preset',
+          status: 'PASS',
+          value: extendsField,
+        })
+      }
+    } catch {
+      checks.push({
+        name: '.release-it.json parseable',
+        status: 'FAIL',
+        value: 'parse error',
+        detail: '.release-it.json contains invalid JSON',
+      })
+    }
+  }
+
+  if (!deps.existsSync('package.json')) {
+    checks.push({
+      name: 'package.json exists',
+      status: 'FAIL',
+      value: 'missing',
+      detail: 'package.json is required for release-it',
+    })
+  } else {
+    try {
+      const raw = deps.readFileSync('package.json', 'utf8') as string
+      const pkg = JSON.parse(raw) as Record<string, unknown>
+      const version = pkg.version as string | undefined
+
+      if (!version) {
+        checks.push({
+          name: 'package.json version',
+          status: 'FAIL',
+          value: 'missing',
+          detail: 'Add "version" field to package.json',
+        })
+      } else if (!isValidSemver(version)) {
+        checks.push({
+          name: 'package.json version',
+          status: 'FAIL',
+          value: version,
+          detail: `"${version}" is not a valid semver string`,
+        })
+      } else {
+        checks.push({ name: 'package.json version', status: 'PASS', value: version })
+      }
+    } catch {
+      checks.push({
+        name: 'package.json parseable',
+        status: 'FAIL',
+        value: 'parse error',
+        detail: 'package.json contains invalid JSON',
+      })
+    }
+  }
+
+  return { checks, status: worstStatus(checks.map((c) => c.status)) }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Summary
+// ---------------------------------------------------------------------------
+
+export function summarize(report: Omit<DoctorReport, 'summary'>): DoctorSummary {
+  const allChecks: CheckResult[] = [
+    ...report.environment.checks,
+    ...report.repository.checks,
+    ...report.configuration.checks,
+  ]
+
+  const pass = allChecks.filter((c) => c.status === 'PASS').length
+  const warn = allChecks.filter((c) => c.status === 'WARN').length
+  const fail = allChecks.filter((c) => c.status === 'FAIL').length
+  const total = allChecks.length
+  const score = `${pass}/${total} checks passing`
+
+  let status: DoctorSummary['status']
+  if (fail > 0) {
+    status = 'BLOCKED'
+  } else if (warn > 0) {
+    status = 'WARNINGS'
+  } else {
+    status = 'READY'
+  }
+
+  const recommendations: string[] = []
+  if (fail > 0) {
+    const failedNames = allChecks.filter((c) => c.status === 'FAIL').map((c) => c.name)
+    const preview = failedNames.slice(0, 2).join(', ') + (failedNames.length > 2 ? '...' : '')
+    recommendations.push(`Fix ${fail} blocking issue(s): ${preview}`)
+  }
+  if (warn > 0) {
+    recommendations.push(`Review ${warn} warning(s) before releasing`)
+  }
+  if (status === 'READY') {
+    recommendations.push('All checks pass — run: release-it-preset validate && release-it-preset default')
+  }
+
+  return { pass, warn, fail, total, score, status, recommendations }
+}
+
+// ---------------------------------------------------------------------------
+// Main exported function (DI)
+// ---------------------------------------------------------------------------
+
+export function runDoctor(deps: DoctorDeps): DoctorReport {
+  const environment = collectEnvironment(deps)
+  const repository = inspectRepository(deps)
+  const configuration = validateConfiguration(deps)
+  const summary = summarize({ environment, repository, configuration })
+  return { environment, repository, configuration, summary }
+}
+
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+
+const ICONS: Record<CheckStatus, string> = {
+  PASS: '[PASS]',
+  WARN: '[WARN]',
+  FAIL: '[FAIL]',
+}
+
+const STATUS_LABELS: Record<DoctorSummary['status'], string> = {
+  READY: 'READY',
+  WARNINGS: 'WARNINGS',
+  BLOCKED: 'BLOCKED',
+}
+
+export function formatHuman(report: DoctorReport): string {
+  const lines: string[] = []
+
+  function sectionHeader(title: string): void {
+    lines.push('')
+    lines.push(title)
+    lines.push('-'.repeat(60))
+  }
+
+  function renderChecks(checks: CheckResult[]): void {
+    for (const check of checks) {
+      const icon = ICONS[check.status]
+      lines.push(`  ${icon} ${check.name}: ${check.value}`)
+      if (check.detail) {
+        lines.push(`       ${check.detail}`)
+      }
+    }
+  }
+
+  lines.push('')
+  lines.push('release-it-preset doctor')
+  lines.push('='.repeat(60))
+
+  sectionHeader('1. Environment')
+  renderChecks(report.environment.checks)
+  lines.push('')
+  lines.push(`  Environment variables (${report.environment.vars.length} total):`)
+  for (const v of report.environment.vars) {
+    const srcLabel = v.source === 'env' ? '(env)' : v.source === 'default' ? '(default)' : '(unset)'
+    const displayVal = v.source === 'unset' ? '<not set>' : (v.value ?? '<not set>')
+    lines.push(`    ${v.name.padEnd(35)} ${displayVal.padEnd(30)} ${srcLabel}`)
+  }
+
+  sectionHeader('2. Repository')
+  renderChecks(report.repository.checks)
+
+  sectionHeader('3. Configuration')
+  renderChecks(report.configuration.checks)
+
+  sectionHeader('4. Readiness Summary')
+  const { summary } = report
+  lines.push(`  Status : ${STATUS_LABELS[summary.status]}`)
+  lines.push(`  Score  : ${summary.score}  (PASS: ${summary.pass}, WARN: ${summary.warn}, FAIL: ${summary.fail})`)
+  if (summary.recommendations.length > 0) {
+    lines.push('')
+    lines.push('  Recommendations:')
+    for (const rec of summary.recommendations) {
+      lines.push(`    * ${rec}`)
+    }
+  }
+  lines.push('')
+
+  return lines.join('\n')
+}
+
+export function formatJson(report: DoctorReport): string {
+  return JSON.stringify(report, null, 2)
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry (guarded)
+// ---------------------------------------------------------------------------
+
+if (process.argv[1] && (process.argv[1].endsWith('doctor.js') || process.argv[1].endsWith('doctor.ts'))) {
+  const isJson = process.argv.includes('--json')
+
+  const deps: DoctorDeps = {
+    execSync,
+    existsSync,
+    readFileSync,
+    getEnv: (key: string) => process.env[key],
+  }
+
+  const report = runDoctor(deps)
+
+  if (isJson) {
+    process.stdout.write(formatJson(report) + '\n')
+  } else {
+    process.stdout.write(formatHuman(report))
+  }
+
+  process.exit(report.summary.status === 'BLOCKED' ? 1 : 0)
+}

--- a/scripts/lib/changelog-types.ts
+++ b/scripts/lib/changelog-types.ts
@@ -1,0 +1,123 @@
+/**
+ * Configurable commit-type → CHANGELOG section mapping.
+ *
+ * Resolution order (highest priority wins):
+ *   1. CHANGELOG_TYPE_MAP env var  (JSON string)
+ *   2. .changelog-types.json file  (project root)
+ *   3. Built-in defaults below
+ *
+ * A value of `false` means "skip this type entirely" (no changelog entry).
+ */
+
+import type { readFileSync as ReadFileSyncFn } from 'node:fs';
+
+/**
+ * Dependencies for loadChangelogTypeMap — follows the project DI pattern.
+ */
+export interface ChangelogTypeDeps {
+  readFileSync: typeof ReadFileSyncFn;
+  getEnv: (key: string) => string | undefined;
+  warn: (message: string) => void;
+}
+
+/**
+ * Built-in commit-type → CHANGELOG section map.
+ * Values are `### SectionName` strings or `false` to suppress.
+ */
+export const BUILTIN_TYPE_MAP: Record<string, string | false> = {
+  feat: '### Added',
+  feature: '### Added',
+  add: '### Added',
+  fix: '### Fixed',
+  bugfix: '### Fixed',
+  security: '### Security',
+  perf: '### Changed',
+  refactor: '### Changed',
+  style: '### Changed',
+  docs: '### Changed',
+  test: '### Changed',
+  chore: '### Changed',
+  build: '### Changed',
+  deps: '### Changed',
+  dependency: '### Changed',
+  dependencies: '### Changed',
+  revert: '### Changed',
+  remove: '### Removed',
+  removed: '### Removed',
+  delete: '### Removed',
+  deleted: '### Removed',
+  ci: false,
+  release: false,
+  hotfix: false,
+  misc: '### Changed',
+};
+
+const CHANGELOG_TYPES_FILE = '.changelog-types.json';
+
+/**
+ * Validate that every value in the map is either a string or false.
+ * Throws on the first invalid entry.
+ */
+function validateMapStructure(map: unknown): asserts map is Record<string, string | false> {
+  if (typeof map !== 'object' || map === null || Array.isArray(map)) {
+    throw new TypeError('Type map must be a plain object');
+  }
+  for (const [key, value] of Object.entries(map as Record<string, unknown>)) {
+    if (typeof value !== 'string' && value !== false) {
+      throw new TypeError(
+        `Invalid value for key "${key}": expected string or false, got ${typeof value}`,
+      );
+    }
+  }
+}
+
+/**
+ * Load the commit-type → CHANGELOG section mapping.
+ *
+ * Priority:
+ *  1. CHANGELOG_TYPE_MAP env var (JSON, merged on top of file + built-in)
+ *  2. .changelog-types.json project file (merged on top of built-in)
+ *  3. BUILTIN_TYPE_MAP (base)
+ *
+ * Malformed JSON or invalid structure → WARN + ignore that layer (fall back to lower priority).
+ */
+export function loadChangelogTypeMap(deps: ChangelogTypeDeps): Record<string, string | false> {
+  let resolved: Record<string, string | false> = { ...BUILTIN_TYPE_MAP };
+
+  // Layer 1: project-level file override
+  let fileContent: string | undefined;
+  try {
+    fileContent = deps.readFileSync(CHANGELOG_TYPES_FILE, 'utf8') as string;
+  } catch {
+    // File does not exist — not an error, just skip
+    fileContent = undefined;
+  }
+
+  if (fileContent !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(fileContent);
+      validateMapStructure(parsed);
+      resolved = { ...resolved, ...parsed };
+    } catch (err) {
+      deps.warn(
+        `Invalid ${CHANGELOG_TYPES_FILE}: ${(err as Error).message}. Using built-in type map.`,
+      );
+    }
+  }
+
+  // Layer 2: env var override (highest priority)
+  const envValue = deps.getEnv('CHANGELOG_TYPE_MAP');
+  if (envValue) {
+    try {
+      const parsed: unknown = JSON.parse(envValue);
+      validateMapStructure(parsed);
+      resolved = { ...resolved, ...parsed };
+    } catch (err) {
+      deps.warn(
+        `Invalid CHANGELOG_TYPE_MAP env var: ${(err as Error).message}. Using file/built-in type map.`,
+      );
+    }
+  }
+
+  return resolved;
+}

--- a/scripts/lib/changelog-types.ts
+++ b/scripts/lib/changelog-types.ts
@@ -88,8 +88,14 @@ export function loadChangelogTypeMap(deps: ChangelogTypeDeps): Record<string, st
   let fileContent: string | undefined;
   try {
     fileContent = deps.readFileSync(CHANGELOG_TYPES_FILE, 'utf8') as string;
-  } catch {
-    // File does not exist — not an error, just skip
+  } catch (err) {
+    // ENOENT (file does not exist) is the expected case — silently skip.
+    // Other I/O errors (EACCES permission denied, EISDIR is a directory, etc.)
+    // are real problems and surfaced as a WARN so the user can investigate.
+    const e = err as NodeJS.ErrnoException;
+    if (e?.code !== 'ENOENT') {
+      deps.warn(`Cannot read ${CHANGELOG_TYPES_FILE}: ${e?.message ?? String(err)}. Skipping file override.`);
+    }
     fileContent = undefined;
   }
 

--- a/scripts/populate-unreleased-changelog.ts
+++ b/scripts/populate-unreleased-changelog.ts
@@ -25,6 +25,7 @@ import { getGitHubRepoUrl } from './lib/git-utils.js';
 import { CONVENTIONAL_COMMIT_REGEX } from './lib/commit-parser.js';
 import { runScript } from './lib/run-script.js';
 import { ValidationError } from './lib/errors.js';
+import { BUILTIN_TYPE_MAP, loadChangelogTypeMap } from './lib/changelog-types.js';
 
 /**
  * Dependencies interface for dependency injection
@@ -73,37 +74,15 @@ export function extractConventionalCommitParts(commitBody: string, sha: string):
 }
 
 /**
- * Normalize commit types to standard changelog categories
+ * Normalize a commit type to a CHANGELOG section heading.
+ * Uses `typeMap` (defaults to BUILTIN_TYPE_MAP) so callers can inject
+ * a custom or project-level override without touching this function.
+ * Returns false when the type should be suppressed entirely.
  */
-export function normalizeCommitType(type: string): string | false {
-  const typeMap: Record<string, string | false> = {
-    feat: '### Added',
-    feature: '### Added',
-    add: '### Added',
-    fix: '### Fixed',
-    bugfix: '### Fixed',
-    security: '### Security',
-    perf: '### Changed',
-    refactor: '### Changed',
-    style: '### Changed',
-    docs: '### Changed',
-    test: '### Changed',
-    chore: '### Changed',
-    build: '### Changed',
-    deps: '### Changed',
-    dependency: '### Changed',
-    dependencies: '### Changed',
-    revert: '### Changed',
-    remove: '### Removed',
-    removed: '### Removed',
-    delete: '### Removed',
-    deleted: '### Removed',
-    ci: false,
-    release: false,
-    hotfix: false,
-    misc: '### Changed',
-  };
-
+export function normalizeCommitType(
+  type: string,
+  typeMap: Record<string, string | false> = BUILTIN_TYPE_MAP,
+): string | false {
   const result = typeMap[type.toLowerCase()];
   return result !== undefined ? result : '### Changed';
 }
@@ -112,7 +91,11 @@ export function normalizeCommitType(type: string): string | false {
 /**
  * Parse git log output and extract all conventional commit parts
  */
-export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: string): string {
+export function parseCommitsWithMultiplePrefixes(
+  gitOutput: string,
+  repoUrl: string,
+  typeMap: Record<string, string | false> = BUILTIN_TYPE_MAP,
+): string {
   if (!gitOutput) return '';
 
   const commitEntries = gitOutput.split('|||END|||').filter((entry) => entry.trim());
@@ -150,18 +133,34 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
 
       const parts = extractConventionalCommitParts(headerBlock, shortSha);
 
-      // Detect "BREAKING CHANGE:" trailer in the full body (not just header).
-      // This handles the footer-style breaking annotation per Conventional Commits spec.
-      const breakingFooterMatch = /^BREAKING[- ]CHANGE:\s*(.+)/m.exec(body);
-      if (breakingFooterMatch) {
+      // F-003: Detect "BREAKING CHANGE:" trailers only in the LAST paragraph of the body,
+      // AND only when the body has more than one paragraph (i.e., there is at least one
+      // blank-line separator). Per Conventional Commits 1.0.0 §6, a footer requires a
+      // blank line separating it from the preceding content. A "BREAKING CHANGE:" that
+      // appears on a line immediately after the subject line (no blank line) is mid-body
+      // prose, NOT a footer, and must NOT promote the commit to breaking.
+      //
+      // F-004: Use matchAll() so multiple BREAKING CHANGE: lines in the same last
+      // paragraph each emit a separate breaking entry.
+      const paragraphs = body.split(/\n[ \t]*\n/);
+      const hasFooterSection = paragraphs.length > 1;
+      const breakingFooterMatches = hasFooterSection
+        ? [...(paragraphs[paragraphs.length - 1] ?? '').matchAll(/^BREAKING[- ]CHANGE:\s*(.+)$/gm)]
+        : [];
+
+      if (breakingFooterMatches.length > 0) {
         if (parts.length > 0) {
-          // Promote the first emitted part to breaking.
+          // Promote the first conventional-commit part to breaking so it appears in
+          // the BREAKING CHANGES section with the commit's own description.
           parts[0] = { ...parts[0], breaking: true };
-        } else {
-          // No leading conventional prefix found; emit a standalone breaking entry.
+        }
+        // Each BREAKING CHANGE: footer line emits its own breaking entry with the
+        // footer's description (distinct from the commit subject).
+        // F-004: Multiple footer lines → multiple entries.
+        for (const m of breakingFooterMatches) {
           parts.push({
             type: 'misc',
-            description: breakingFooterMatch[1].trim(),
+            description: m[1].trim(),
             sha: shortSha,
             breaking: true,
           });
@@ -173,13 +172,13 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
         if (firstLine) {
           const lowerFirstLine = firstLine.toLowerCase();
           const ignoredPatterns = [
-        /^release\b/,
-        /^hotfix\b/,
-        /^ci\b/,
-        /^chore\(release\)/i,
-        /^chore\(hotfix\)/i,
-        /^chore\(ci\)/i,
-      ];
+            /^release\b/,
+            /^hotfix\b/,
+            /^ci\b/,
+            /^chore\(release\)/i,
+            /^chore\(hotfix\)/i,
+            /^chore\(ci\)/i,
+          ];
           const shouldSkip = ignoredPatterns.some((pattern) => pattern.test(lowerFirstLine));
 
           if (shouldSkip) {
@@ -202,12 +201,17 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
   const breakingChanges: CommitPart[] = [];
 
   for (const part of allParts) {
-    // Collect breaking changes separately
+    // F-002: Breaking parts go ONLY into the BREAKING CHANGES section.
+    // They are NOT also added to their native section (e.g. ### Added), which
+    // would produce duplicate entries. The breaking indicator in the native
+    // section was confusing — the dedicated ### ⚠️ BREAKING CHANGES section
+    // already provides full visibility.
     if (part.breaking) {
       breakingChanges.push(part);
+      continue;
     }
 
-    const sectionName = normalizeCommitType(part.type);
+    const sectionName = normalizeCommitType(part.type, typeMap);
     if (sectionName === false) {
       continue;
     }
@@ -217,8 +221,22 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
     groupedParts[sectionName].push(part);
   }
 
+  // Build the final ordered section list.
+  // Custom sections (from typeMap overrides) are appended after the standard order.
   const sections: string[] = [];
-  const sectionOrder = ['### Added', '### Fixed', '### Changed', '### Removed', '### Security'];
+  const standardSectionOrder = [
+    '### Added',
+    '### Fixed',
+    '### Changed',
+    '### Removed',
+    '### Security',
+  ];
+
+  // Collect any custom section names not in the standard order
+  const customSections = Object.keys(groupedParts).filter(
+    (s) => !standardSectionOrder.includes(s),
+  );
+  const sectionOrder = [...standardSectionOrder, ...customSections];
 
   // Add BREAKING CHANGES section first if there are any
   if (breakingChanges.length > 0) {
@@ -239,9 +257,8 @@ export function parseCommitsWithMultiplePrefixes(gitOutput: string, repoUrl: str
       sections.push(
         ...groupedParts[sectionTitle].map((part) => {
           const scopePart = part.scope ? ` (${part.scope})` : '';
-          const breakingIndicator = part.breaking ? ' ⚠️ BREAKING' : '';
           const linkPart = repoUrl ? ` ([${part.sha}](${repoUrl}/commit/${part.sha}))` : ` (${part.sha})`;
-          return `- ${part.description}${scopePart}${breakingIndicator}${linkPart}`;
+          return `- ${part.description}${scopePart}${linkPart}`;
         })
       );
       sections.push('');
@@ -359,7 +376,12 @@ export function populateChangelog(deps: PopulateChangelogDeps): void {
     getEnv: deps.getEnv,
     warn: deps.warn,
   });
-  const commits = parseCommitsWithMultiplePrefixes(gitOutput, repoUrl);
+  const typeMap = loadChangelogTypeMap({
+    readFileSync: deps.readFileSync,
+    getEnv: deps.getEnv,
+    warn: deps.warn,
+  });
+  const commits = parseCommitsWithMultiplePrefixes(gitOutput, repoUrl, typeMap);
   const changelog = deps.readFileSync(changelogPath, 'utf8') as string;
   const unreleasedContent = commits && commits.trim() ? commits : 'No changes yet.';
   const unreleasedRegex = /## \[Unreleased\][\s\S]*?(?=## \[|$)/;

--- a/scripts/populate-unreleased-changelog.ts
+++ b/scripts/populate-unreleased-changelog.ts
@@ -142,7 +142,9 @@ export function parseCommitsWithMultiplePrefixes(
       //
       // F-004: Use matchAll() so multiple BREAKING CHANGE: lines in the same last
       // paragraph each emit a separate breaking entry.
-      const paragraphs = body.split(/\n[ \t]*\n/);
+      // CRLF safety: accept both LF and CRLF line endings so commits authored on
+      // Windows produce the same output (a paragraph separator can be \n\n or \r\n\r\n).
+      const paragraphs = body.split(/\r?\n[ \t]*\r?\n/);
       const hasFooterSection = paragraphs.length > 1;
       const breakingFooterMatches = hasFooterSection
         ? [...(paragraphs[paragraphs.length - 1] ?? '').matchAll(/^BREAKING[- ]CHANGE:\s*(.+)$/gm)]

--- a/tests/unit/changelog-types.test.ts
+++ b/tests/unit/changelog-types.test.ts
@@ -33,11 +33,27 @@ describe('changelog-types', () => {
   describe('loadChangelogTypeMap', () => {
     it('returns built-in map when no file and no env var', () => {
       vi.mocked(deps.readFileSync).mockImplementation(() => {
-        throw new Error('ENOENT: file not found')
+        const err = new Error('ENOENT: no such file or directory') as NodeJS.ErrnoException
+        err.code = 'ENOENT'
+        throw err
       })
       const result = loadChangelogTypeMap(deps)
       expect(result).toEqual(BUILTIN_TYPE_MAP)
       expect(deps.warn).not.toHaveBeenCalled()
+    })
+
+    it('non-ENOENT file errors (e.g. EACCES) surface as a WARN', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        const err = new Error('EACCES: permission denied') as NodeJS.ErrnoException
+        err.code = 'EACCES'
+        throw err
+      })
+      const result = loadChangelogTypeMap(deps)
+      // Falls back to built-in because file couldn't be read
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot read .changelog-types.json'),
+      )
     })
 
     it('file overrides built-in (custom type maps to custom section)', () => {

--- a/tests/unit/changelog-types.test.ts
+++ b/tests/unit/changelog-types.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  BUILTIN_TYPE_MAP,
+  type ChangelogTypeDeps,
+  loadChangelogTypeMap,
+} from '../../scripts/lib/changelog-types'
+
+describe('changelog-types', () => {
+  let deps: ChangelogTypeDeps
+
+  beforeEach(() => {
+    deps = {
+      readFileSync: vi.fn(),
+      getEnv: vi.fn((_key: string) => undefined),
+      warn: vi.fn(),
+    }
+  })
+
+  describe('BUILTIN_TYPE_MAP', () => {
+    it('should map feat/feature/add to Added', () => {
+      expect(BUILTIN_TYPE_MAP['feat']).toBe('### Added')
+      expect(BUILTIN_TYPE_MAP['feature']).toBe('### Added')
+      expect(BUILTIN_TYPE_MAP['add']).toBe('### Added')
+    })
+
+    it('should suppress ci/release/hotfix (false)', () => {
+      expect(BUILTIN_TYPE_MAP['ci']).toBe(false)
+      expect(BUILTIN_TYPE_MAP['release']).toBe(false)
+      expect(BUILTIN_TYPE_MAP['hotfix']).toBe(false)
+    })
+  })
+
+  describe('loadChangelogTypeMap', () => {
+    it('returns built-in map when no file and no env var', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT: file not found')
+      })
+      const result = loadChangelogTypeMap(deps)
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+      expect(deps.warn).not.toHaveBeenCalled()
+    })
+
+    it('file overrides built-in (custom type maps to custom section)', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue(
+        JSON.stringify({ deps: '### Dependencies', ops: '### Operations' }),
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(result['deps']).toBe('### Dependencies')
+      expect(result['ops']).toBe('### Operations')
+      // built-in entries are preserved
+      expect(result['feat']).toBe('### Added')
+    })
+
+    it('env var overrides file override (env wins)', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue(JSON.stringify({ deps: '### Dependencies' }))
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP' ? JSON.stringify({ deps: '### Bumps' }) : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      // env wins over file
+      expect(result['deps']).toBe('### Bumps')
+    })
+
+    it('env var false value suppresses a type', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP' ? JSON.stringify({ deps: false }) : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(result['deps']).toBe(false)
+    })
+
+    it('malformed env JSON → WARN + falls back to file/built-in', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue(JSON.stringify({ ops: '### Ops' }))
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP' ? 'NOT VALID JSON{{{{' : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid CHANGELOG_TYPE_MAP env var'),
+      )
+      // file layer still applied
+      expect(result['ops']).toBe('### Ops')
+    })
+
+    it('malformed file JSON → WARN + falls back to built-in', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue('{ bad json ]]]')
+      const result = loadChangelogTypeMap(deps)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid .changelog-types.json'),
+      )
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+    })
+
+    it('file with invalid value type → WARN + falls back to built-in', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue(
+        JSON.stringify({ deps: 42 }), // 42 is not string | false
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid .changelog-types.json'),
+      )
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+    })
+
+    it('env var with invalid value type → WARN + falls back to file/built-in', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP' ? JSON.stringify({ deps: 99 }) : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid CHANGELOG_TYPE_MAP env var'),
+      )
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+    })
+
+    it('missing file (ENOENT) is silently ignored — no warn', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      })
+      loadChangelogTypeMap(deps)
+      expect(deps.warn).not.toHaveBeenCalled()
+    })
+
+    it('env var array instead of object → WARN + falls back', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(() => {
+        throw new Error('ENOENT')
+      })
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP' ? JSON.stringify(['deps', 'ops']) : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(deps.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid CHANGELOG_TYPE_MAP env var'),
+      )
+      expect(result).toEqual(BUILTIN_TYPE_MAP)
+    })
+
+    it('both file and env var valid → result is built-in merged with file merged with env', () => {
+      vi.mocked(deps.readFileSync).mockReturnValue(
+        JSON.stringify({ custom1: '### Custom1', feat: '### NewAdded' }),
+      )
+      vi.mocked(deps.getEnv).mockImplementation(key =>
+        key === 'CHANGELOG_TYPE_MAP'
+          ? JSON.stringify({ custom2: '### Custom2', feat: '### EnvAdded' })
+          : undefined,
+      )
+      const result = loadChangelogTypeMap(deps)
+      expect(result['custom1']).toBe('### Custom1') // from file
+      expect(result['custom2']).toBe('### Custom2') // from env
+      expect(result['feat']).toBe('### EnvAdded') // env wins over file
+      expect(result['fix']).toBe('### Fixed') // built-in preserved
+    })
+  })
+})

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -1,0 +1,579 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type CheckResult,
+  collectEnvironment,
+  type DoctorDeps,
+  type DoctorReport,
+  type DoctorSummary,
+  formatHuman,
+  formatJson,
+  inspectRepository,
+  runDoctor,
+  safeExec,
+  summarize,
+  validateConfiguration,
+} from '../../scripts/doctor'
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<DoctorDeps> = {}): DoctorDeps {
+  return {
+    execSync: vi.fn(),
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn(),
+    getEnv: vi.fn((_key: string) => undefined),
+    ...overrides,
+  }
+}
+
+const VALID_CHANGELOG = `# Changelog
+
+## [Unreleased]
+- Added something great
+
+## [0.1.0] - 2024-01-01
+### Added
+- Initial release
+`
+
+const VALID_PACKAGE_JSON = JSON.stringify({ name: 'my-pkg', version: '0.1.0' })
+
+const VALID_RELEASE_IT_JSON = JSON.stringify({
+  extends: '@oorabona/release-it-preset/config/default',
+})
+
+// ---------------------------------------------------------------------------
+// safeExec
+// ---------------------------------------------------------------------------
+
+describe('safeExec', () => {
+  it('returns trimmed stdout on success', () => {
+    const deps = makeDeps({ execSync: vi.fn().mockReturnValue('  v0.1.0\n') })
+    expect(safeExec('git describe --tags', deps)).toBe('v0.1.0')
+  })
+
+  it('returns null when command throws', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    expect(safeExec('git describe --tags', deps)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// collectEnvironment
+// ---------------------------------------------------------------------------
+
+describe('collectEnvironment', () => {
+  it('all defaults — no env set — returns PASS status', () => {
+    const deps = makeDeps()
+    const section = collectEnvironment(deps)
+    expect(section.status).toBe('PASS')
+    expect(section.vars.length).toBeGreaterThan(0)
+    expect(section.vars.find(v => v.name === 'CHANGELOG_FILE')?.source).toBe('default')
+  })
+
+  it('env vars from process env are marked source=env', () => {
+    const deps = makeDeps({
+      getEnv: vi.fn((k: string) => (k === 'NPM_PUBLISH' ? 'true' : undefined)),
+    })
+    const section = collectEnvironment(deps)
+    const npmPublishVar = section.vars.find(v => v.name === 'NPM_PUBLISH')
+    expect(npmPublishVar?.source).toBe('env')
+    expect(npmPublishVar?.value).toBe('true')
+  })
+
+  it('GITHUB_RELEASE=true without GITHUB_REPOSITORY => WARN', () => {
+    const deps = makeDeps({
+      getEnv: vi.fn((k: string) => {
+        if (k === 'GITHUB_RELEASE') {
+          return 'true'
+        }
+        return undefined
+      }),
+    })
+    const section = collectEnvironment(deps)
+    expect(section.status).toBe('WARN')
+    const warnCheck = section.checks.find(c => c.status === 'WARN')
+    expect(warnCheck).toBeDefined()
+  })
+
+  it('GITHUB_RELEASE=true WITH GITHUB_REPOSITORY => PASS', () => {
+    const deps = makeDeps({
+      getEnv: vi.fn((k: string) => {
+        if (k === 'GITHUB_RELEASE') {
+          return 'true'
+        }
+        if (k === 'GITHUB_REPOSITORY') {
+          return 'owner/repo'
+        }
+        return undefined
+      }),
+    })
+    const section = collectEnvironment(deps)
+    expect(section.status).toBe('PASS')
+  })
+
+  it('unset optional vars are marked source=unset', () => {
+    const deps = makeDeps()
+    const section = collectEnvironment(deps)
+    const optional = section.vars.find(v => v.name === 'GIT_CHANGELOG_PATH')
+    expect(optional?.source).toBe('unset')
+    expect(optional?.value).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// inspectRepository
+// ---------------------------------------------------------------------------
+
+describe('inspectRepository', () => {
+  it('returns FAIL immediately when not a git repository', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const section = inspectRepository(deps)
+    expect(section.status).toBe('FAIL')
+    expect(section.checks[0].name).toBe('Git repository')
+    expect(section.checks[0].status).toBe('FAIL')
+    expect(section.checks).toHaveLength(1)
+  })
+
+  it('returns PASS for clean repo on required branch with upstream', () => {
+    const deps = makeDeps({
+      execSync: vi.fn((cmd: string) => {
+        if (cmd.includes('rev-parse --git-dir')) {
+          return '.git'
+        }
+        if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+          return 'main'
+        }
+        if (cmd.includes('describe --tags')) {
+          return 'v0.1.0'
+        }
+        if (cmd.includes('rev-list') && cmd.includes('--count')) {
+          return '3'
+        }
+        if (cmd.includes('status --porcelain')) {
+          return ''
+        }
+        if (cmd.includes('rev-parse --abbrev-ref @{u}')) {
+          return 'origin/main'
+        }
+        if (cmd.includes('config --get remote.origin.url')) {
+          return 'https://github.com/o/r'
+        }
+        return ''
+      }),
+    })
+    const section = inspectRepository(deps)
+    expect(section.status).toBe('PASS')
+    expect(section.checks.every(c => c.status === 'PASS')).toBe(true)
+  })
+
+  it('WARN when branch differs from GIT_REQUIRE_BRANCH', () => {
+    const deps = makeDeps({
+      execSync: vi.fn((cmd: string) => {
+        if (cmd.includes('rev-parse --git-dir')) {
+          return '.git'
+        }
+        if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+          return 'feat/some-feature'
+        }
+        if (cmd.includes('describe --tags')) {
+          return 'v0.1.0'
+        }
+        if (cmd.includes('rev-list') && cmd.includes('--count')) {
+          return '0'
+        }
+        if (cmd.includes('status --porcelain')) {
+          return ''
+        }
+        if (cmd.includes('rev-parse --abbrev-ref @{u}')) {
+          return 'origin/feat/some-feature'
+        }
+        if (cmd.includes('config --get remote.origin.url')) {
+          return 'https://github.com/o/r'
+        }
+        return ''
+      }),
+      getEnv: vi.fn((k: string) => (k === 'GIT_REQUIRE_BRANCH' ? 'main' : undefined)),
+    })
+    const section = inspectRepository(deps)
+    expect(section.status).toBe('WARN')
+    const branchCheck = section.checks.find(c => c.name === 'Current branch')
+    expect(branchCheck?.status).toBe('WARN')
+  })
+
+  it('WARN when working directory is dirty', () => {
+    const deps = makeDeps({
+      execSync: vi.fn((cmd: string) => {
+        if (cmd.includes('rev-parse --git-dir')) {
+          return '.git'
+        }
+        if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+          return 'main'
+        }
+        if (cmd.includes('describe --tags')) {
+          return 'v0.1.0'
+        }
+        if (cmd.includes('rev-list') && cmd.includes('--count')) {
+          return '1'
+        }
+        if (cmd.includes('status --porcelain')) {
+          return ' M some-file.ts'
+        }
+        if (cmd.includes('rev-parse --abbrev-ref @{u}')) {
+          return 'origin/main'
+        }
+        if (cmd.includes('config --get remote.origin.url')) {
+          return 'https://github.com/o/r'
+        }
+        return ''
+      }),
+    })
+    const section = inspectRepository(deps)
+    const dirtyCheck = section.checks.find(c => c.name === 'Working directory clean')
+    expect(dirtyCheck?.status).toBe('WARN')
+  })
+
+  it('WARN when no upstream tracking branch', () => {
+    const deps = makeDeps({
+      execSync: vi.fn((cmd: string) => {
+        if (cmd.includes('rev-parse --git-dir')) {
+          return '.git'
+        }
+        if (cmd.includes('rev-parse --abbrev-ref HEAD')) {
+          return 'main'
+        }
+        if (cmd.includes('describe --tags')) {
+          return 'v0.1.0'
+        }
+        if (cmd.includes('rev-list') && cmd.includes('--count')) {
+          return '0'
+        }
+        if (cmd.includes('status --porcelain')) {
+          return ''
+        }
+        if (cmd.includes('rev-parse --abbrev-ref @{u}')) {
+          throw new Error('no upstream')
+        }
+        if (cmd.includes('config --get remote.origin.url')) {
+          return 'https://github.com/o/r'
+        }
+        return ''
+      }),
+    })
+    const section = inspectRepository(deps)
+    const upstreamCheck = section.checks.find(c => c.name === 'Upstream tracking branch')
+    expect(upstreamCheck?.status).toBe('WARN')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateConfiguration
+// ---------------------------------------------------------------------------
+
+describe('validateConfiguration', () => {
+  it('FAIL when CHANGELOG.md is missing', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn().mockReturnValue(false),
+    })
+    const section = validateConfiguration(deps)
+    expect(section.status).toBe('FAIL')
+    const check = section.checks.find(c => c.name.includes('exists'))
+    expect(check?.status).toBe('FAIL')
+  })
+
+  it('FAIL when CHANGELOG.md lacks Keep a Changelog header', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'CHANGELOG.md'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'CHANGELOG.md') {
+          return '## [Unreleased]\n- something\n'
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const formatCheck = section.checks.find(c => c.name === 'Keep a Changelog format')
+    expect(formatCheck?.status).toBe('FAIL')
+  })
+
+  it('WARN when [Unreleased] section is empty', () => {
+    const emptyChangelog = '# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2024-01-01\n'
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'CHANGELOG.md'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'CHANGELOG.md') {
+          return emptyChangelog
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const unreleasedCheck = section.checks.find(c => c.name === '[Unreleased] section')
+    expect(unreleasedCheck?.status).toBe('WARN')
+  })
+
+  it('PASS when all configuration files are valid', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn().mockReturnValue(true),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'CHANGELOG.md') {
+          return VALID_CHANGELOG
+        }
+        if (p === '.release-it.json') {
+          return VALID_RELEASE_IT_JSON
+        }
+        if (p === 'package.json') {
+          return VALID_PACKAGE_JSON
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    expect(section.status).toBe('PASS')
+    expect(section.checks.every(c => c.status === 'PASS')).toBe(true)
+  })
+
+  it('FAIL when package.json version is not valid semver', () => {
+    const badPkg = JSON.stringify({ name: 'my-pkg', version: 'not-a-version' })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') {
+          return badPkg
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const versionCheck = section.checks.find(c => c.name === 'package.json version')
+    expect(versionCheck?.status).toBe('FAIL')
+  })
+
+  it('WARN when .release-it.json does not extend preset', () => {
+    const badConfig = JSON.stringify({ plugins: {} })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) =>
+        ['CHANGELOG.md', '.release-it.json', 'package.json'].includes(p),
+      ),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'CHANGELOG.md') {
+          return VALID_CHANGELOG
+        }
+        if (p === '.release-it.json') {
+          return badConfig
+        }
+        if (p === 'package.json') {
+          return VALID_PACKAGE_JSON
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const extendsCheck = section.checks.find(c => c.name === '.release-it.json extends preset')
+    expect(extendsCheck?.status).toBe('WARN')
+  })
+
+  it('FAIL when .release-it.json is invalid JSON', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) =>
+        ['CHANGELOG.md', '.release-it.json', 'package.json'].includes(p),
+      ),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'CHANGELOG.md') {
+          return VALID_CHANGELOG
+        }
+        if (p === '.release-it.json') {
+          return '{ invalid json'
+        }
+        if (p === 'package.json') {
+          return VALID_PACKAGE_JSON
+        }
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const parseCheck = section.checks.find(c => c.name === '.release-it.json parseable')
+    expect(parseCheck?.status).toBe('FAIL')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// summarize
+// ---------------------------------------------------------------------------
+
+describe('summarize', () => {
+  function makeReport(
+    envChecks: CheckResult[],
+    repoChecks: CheckResult[],
+    configChecks: CheckResult[],
+  ): Omit<DoctorReport, 'summary'> {
+    return {
+      environment: {
+        checks: envChecks,
+        vars: [],
+        status: 'PASS',
+      },
+      repository: { checks: repoChecks, status: 'PASS' },
+      configuration: { checks: configChecks, status: 'PASS' },
+    }
+  }
+
+  it('status is READY when all checks pass', () => {
+    const passCheck: CheckResult = { name: 'x', status: 'PASS', value: 'ok' }
+    const report = makeReport([passCheck], [passCheck], [passCheck])
+    const summary = summarize(report)
+    expect(summary.status).toBe('READY')
+    expect(summary.pass).toBe(3)
+    expect(summary.fail).toBe(0)
+    expect(summary.warn).toBe(0)
+    expect(summary.score).toBe('3/3 checks passing')
+    expect(summary.recommendations).toHaveLength(1)
+    expect(summary.recommendations[0]).toMatch(/All checks pass/)
+  })
+
+  it('status is WARNINGS when there are WARNs but no FAILs', () => {
+    const pass: CheckResult = { name: 'x', status: 'PASS', value: 'ok' }
+    const warn: CheckResult = { name: 'y', status: 'WARN', value: 'hmm' }
+    const report = makeReport([pass], [warn], [pass])
+    const summary = summarize(report)
+    expect(summary.status).toBe('WARNINGS')
+    expect(summary.warn).toBe(1)
+    expect(summary.recommendations.some(r => r.includes('warning'))).toBe(true)
+  })
+
+  it('status is BLOCKED when any check is FAIL', () => {
+    const fail: CheckResult = { name: 'z', status: 'FAIL', value: 'nope' }
+    const report = makeReport([fail], [], [])
+    const summary = summarize(report)
+    expect(summary.status).toBe('BLOCKED')
+    expect(summary.fail).toBe(1)
+    expect(summary.recommendations.some(r => r.includes('blocking'))).toBe(true)
+  })
+
+  it('score format is N/M checks passing', () => {
+    const pass: CheckResult = { name: 'a', status: 'PASS', value: 'v' }
+    const fail: CheckResult = { name: 'b', status: 'FAIL', value: 'v' }
+    const report = makeReport([pass, fail], [], [])
+    const summary = summarize(report)
+    expect(summary.score).toBe('1/2 checks passing')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// runDoctor (integration: all sections + summary)
+// ---------------------------------------------------------------------------
+
+describe('runDoctor', () => {
+  it('returns report with all four sections', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    expect(report).toHaveProperty('environment')
+    expect(report).toHaveProperty('repository')
+    expect(report).toHaveProperty('configuration')
+    expect(report).toHaveProperty('summary')
+  })
+
+  it('summary.status is BLOCKED when repo check fails', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    expect(report.summary.status).toBe('BLOCKED')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatJson
+// ---------------------------------------------------------------------------
+
+describe('formatJson', () => {
+  it('output is parseable JSON with all 4 sections', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    const json = formatJson(report)
+    const parsed = JSON.parse(json) as DoctorReport
+    expect(parsed).toHaveProperty('environment')
+    expect(parsed).toHaveProperty('repository')
+    expect(parsed).toHaveProperty('configuration')
+    expect(parsed.summary).toHaveProperty('score')
+    expect(parsed.summary).toHaveProperty('status')
+    expect(parsed.summary).toHaveProperty('recommendations')
+  })
+
+  it('--json output has correct summary shape', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    const parsed = JSON.parse(formatJson(report)) as { summary: DoctorSummary }
+    expect(typeof parsed.summary.pass).toBe('number')
+    expect(typeof parsed.summary.fail).toBe('number')
+    expect(typeof parsed.summary.warn).toBe('number')
+    expect(typeof parsed.summary.total).toBe('number')
+    expect(['READY', 'WARNINGS', 'BLOCKED']).toContain(parsed.summary.status)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// formatHuman
+// ---------------------------------------------------------------------------
+
+describe('formatHuman', () => {
+  it('contains all 4 section headers', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    const output = formatHuman(report)
+    expect(output).toMatch(/1\. Environment/)
+    expect(output).toMatch(/2\. Repository/)
+    expect(output).toMatch(/3\. Configuration/)
+    expect(output).toMatch(/4\. Readiness Summary/)
+  })
+
+  it('contains PASS/WARN/FAIL markers', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    const output = formatHuman(report)
+    expect(output).toMatch(/\[PASS\]|\[WARN\]|\[FAIL\]/)
+  })
+
+  it('shows status in summary', () => {
+    const deps = makeDeps({
+      execSync: vi.fn().mockImplementation(() => {
+        throw new Error('not a git repo')
+      }),
+    })
+    const report = runDoctor(deps)
+    const output = formatHuman(report)
+    expect(output).toMatch(/Status\s*:\s*(READY|WARNINGS|BLOCKED)/)
+  })
+})

--- a/tests/unit/populate-unreleased-changelog.test.ts
+++ b/tests/unit/populate-unreleased-changelog.test.ts
@@ -730,6 +730,17 @@ describe('populate-unreleased-changelog (with DI)', () => {
       // The commit still appears as a regular Added entry
       expect(result).toContain('### Added')
     })
+
+    it('CRLF body with proper blank-line BREAKING CHANGE footer DOES promote', () => {
+      // Windows-authored commit: paragraph separator is \r\n\r\n, not \n\n.
+      // The splitter must accept both line endings so the footer is detected.
+      const gitOutput =
+        'abc1234567890|feat: rewrite parser\r\n\r\nBREAKING CHANGE: rule names changed|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('rewrite parser')
+    })
   })
 
   describe('custom type map: normalizeCommitType with override', () => {

--- a/tests/unit/populate-unreleased-changelog.test.ts
+++ b/tests/unit/populate-unreleased-changelog.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BUILTIN_TYPE_MAP } from '../../scripts/lib/changelog-types'
 import { ValidationError } from '../../scripts/lib/errors'
 import { getGitHubRepoUrl } from '../../scripts/lib/git-utils'
 import {
@@ -489,7 +490,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
           ([cmd]) => typeof cmd === 'string' && cmd.startsWith('git log'),
         )
         expect(gitLogCall).toBeDefined()
-        expect(gitLogCall![0]).toContain(' -- packages/tar-xz')
+        expect(gitLogCall?.[0]).toContain(' -- packages/tar-xz')
       })
 
       it('should throw ValidationError when GIT_CHANGELOG_PATH starts with ..', () => {
@@ -526,7 +527,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
           ([cmd]) => typeof cmd === 'string' && cmd.startsWith('git log'),
         )
         expect(gitLogCall).toBeDefined()
-        expect(gitLogCall![0]).not.toContain(' -- ')
+        expect(gitLogCall?.[0]).not.toContain(' -- ')
       })
     })
   })
@@ -596,6 +597,189 @@ describe('populate-unreleased-changelog (with DI)', () => {
       vi.mocked(deps.execSync).mockReturnValue('v0.1.0\n')
       const result = resolveSinceBaseline(deps)
       expect(result).toBe('v0.1.0')
+    })
+  })
+
+  describe('F-002: breaking parts dedupe (only in BREAKING CHANGES, not in native section)', () => {
+    it('bang-style breaking commit appears ONLY in BREAKING CHANGES, not in ### Added', () => {
+      const gitOutput = 'abc1234567890|feat!: migrate config format|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('migrate config format')
+      // exactly one occurrence in the whole output (dedupe: not also in ### Added)
+      expect((result.match(/migrate config format/g) ?? []).length).toBe(1)
+      expect(result).not.toContain('### Added')
+    })
+
+    it('BREAKING CHANGE footer entry appears ONLY in BREAKING CHANGES, not in ### Added', () => {
+      const gitOutput =
+        'abc1234567890|feat: add big thing\n\nBREAKING CHANGE: config schema changed|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('add big thing')
+      // dedupe: appears exactly once
+      expect((result.match(/add big thing/g) ?? []).length).toBe(1)
+      expect(result).not.toContain('### Added')
+    })
+  })
+
+  describe('F-003: strict BREAKING CHANGE: footer (requires blank-line separation)', () => {
+    it('mid-body BREAKING CHANGE (no blank line) does NOT promote to breaking', () => {
+      // No blank line between header and "BREAKING CHANGE:" — not a footer
+      const gitOutput = 'abc1234567890|feat: x\nBREAKING CHANGE: not a footer|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).not.toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('### Added')
+      expect(result).toContain('- x')
+    })
+
+    it('proper footer BREAKING CHANGE (blank line before) DOES promote to breaking', () => {
+      const gitOutput = 'abc1234567890|feat: x\n\nBREAKING CHANGE: real footer|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('x')
+      // dedupe: only in breaking section
+      expect(result).not.toContain('### Added')
+    })
+
+    it('BREAKING-CHANGE (hyphen variant) in proper footer promotes to breaking', () => {
+      const gitOutput = 'abc1234567890|feat: y\n\nBREAKING-CHANGE: hyphen variant|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('hyphen variant')
+    })
+  })
+
+  describe('F-004: multi-footer BREAKING CHANGE (multiple lines in last paragraph)', () => {
+    it('two BREAKING CHANGE lines in last paragraph emit two breaking entries', () => {
+      const gitOutput =
+        'abc1234567890|feat: big refactor\n\nBREAKING CHANGE: API changed\nBREAKING CHANGE: config changed|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('API changed')
+      expect(result).toContain('config changed')
+      // both breaking lines present
+      expect((result.match(/API changed/g) ?? []).length).toBe(1)
+      expect((result.match(/config changed/g) ?? []).length).toBe(1)
+    })
+
+    it('standalone commit (no prefix) with two BREAKING CHANGE footers emits two entries', () => {
+      const gitOutput =
+        'abc1234567890|Non-conventional subject\n\nBREAKING CHANGE: removed foo\nBREAKING CHANGE: removed bar|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### ⚠️ BREAKING CHANGES')
+      expect(result).toContain('removed foo')
+      expect(result).toContain('removed bar')
+    })
+  })
+
+  describe('F-005: entry-count locks on AC#3 and AC#5', () => {
+    it('AC#3 after F-002 dedupe: BREAKING CHANGE footer entry appears exactly once', () => {
+      const gitOutput =
+        'abc1234567890|feat: migrate config format\n\nUsers must update their config file.\nBREAKING CHANGE: config schema changed|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      // "migrate config format" should appear exactly once (not duplicated across sections)
+      expect((result.match(/migrate config format/g) ?? []).length).toBe(1)
+    })
+
+    it('AC#5: two consecutive prefix lines emit exactly one entry each', () => {
+      const gitOutput = 'abc1234567890|feat: add X\nfix: fix Y|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect((result.match(/add X/g) ?? []).length).toBe(1)
+      expect((result.match(/fix Y/g) ?? []).length).toBe(1)
+    })
+  })
+
+  describe('F-006: edge cases (CRLF, whitespace-only separator, mid-body BREAKING CHANGE)', () => {
+    it('CRLF line endings are handled correctly', () => {
+      // Windows-style \r\n — blank line is \r\n\r\n
+      const gitOutput = 'abc1234567890|feat: x\r\n\r\nbody\r\nRefs: #1|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### Added')
+      expect(result).toContain('x')
+      // Refs: line must NOT become a changelog entry
+      expect(result).not.toMatch(/- Refs/m)
+    })
+
+    it('whitespace-only line acts as paragraph separator', () => {
+      // A line with only spaces is a blank-line separator per the spec
+      const gitOutput = 'abc1234567890|feat: x\n   \nbody text|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).toContain('### Added')
+      expect(result).toContain('x')
+      // "body text" must not be a changelog entry
+      expect(result).not.toContain('body text')
+    })
+
+    it('mid-body BREAKING CHANGE without blank-line separator is not treated as footer', () => {
+      const gitOutput = 'abc1234567890|feat: x\nBREAKING CHANGE: not a footer|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
+
+      expect(result).not.toContain('### ⚠️ BREAKING CHANGES')
+      // The commit still appears as a regular Added entry
+      expect(result).toContain('### Added')
+    })
+  })
+
+  describe('custom type map: normalizeCommitType with override', () => {
+    it('custom typeMap routes unknown type to custom section', () => {
+      const customMap = { ...BUILTIN_TYPE_MAP, deps: '### Dependencies' }
+      expect(normalizeCommitType('deps', customMap)).toBe('### Dependencies')
+    })
+
+    it('custom typeMap false value suppresses type', () => {
+      const customMap = { ...BUILTIN_TYPE_MAP, docs: false as const }
+      expect(normalizeCommitType('docs', customMap)).toBe(false)
+    })
+
+    it('env CHANGELOG_TYPE_MAP routes deps commits to custom section via parseCommitsWithMultiplePrefixes', () => {
+      const customMap = { ...BUILTIN_TYPE_MAP, deps: '### Dependencies' }
+      const gitOutput = 'abc1234567890|deps: bump foo to 1.2.3|||END|||'
+      const result = parseCommitsWithMultiplePrefixes(
+        gitOutput,
+        'https://github.com/owner/repo',
+        customMap,
+      )
+
+      expect(result).toContain('### Dependencies')
+      expect(result).toContain('bump foo to 1.2.3')
+      expect(result).not.toContain('### Changed')
+    })
+
+    it('populateChangelog uses CHANGELOG_TYPE_MAP env var to route custom types', () => {
+      vi.mocked(deps.readFileSync).mockImplementation(path => {
+        if (path === '.changelog-types.json') {
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+        }
+        return '# Changelog\n\n## [Unreleased]\n\nNo changes yet.\n\n'
+      })
+      vi.mocked(deps.getEnv).mockImplementation(key => {
+        if (key === 'CHANGELOG_TYPE_MAP') {
+          return JSON.stringify({ ops: '### Operations' })
+        }
+        return undefined
+      })
+      vi.mocked(deps.execSync)
+        .mockReturnValueOnce('v1.0.0') // git describe
+        .mockReturnValueOnce('abc1234567890|ops: deploy infra|||END|||') // git log
+        .mockReturnValueOnce('') // git remote (getGitHubRepoUrl)
+
+      populateChangelog(deps)
+
+      const writtenContent = vi.mocked(deps.writeFileSync).mock.calls[0][1] as string
+      expect(writtenContent).toContain('### Operations')
+      expect(writtenContent).toContain('deploy infra')
     })
   })
 })


### PR DESCRIPTION
## Summary

v0.15.0 bundles the last three feature work items from the v1.0 staging plan:

1. **`release-it-preset doctor`** (#25) — new diagnostic CLI command. Runs a structured 4-section checklist (Environment, Repository, Configuration, Readiness Summary) and reports a PASS/WARN/FAIL score. Human output for interactive use, `--json` for CI integration.

2. **Configurable commit-type → CHANGELOG section mapping** (#26) — users can now override the built-in mapping via `.changelog-types.json` file (project-level) or `CHANGELOG_TYPE_MAP` env var (highest priority, JSON string). Resolution order: env > file > built-in default, matching the project's existing env-var-overrides-default convention.

3. **4 follow-up findings F-002..F-006 from PR #27 review** (folded into #26 scope):
   - **F-002**: breaking commits no longer dual-emit. They appear ONLY under `### ⚠️ BREAKING CHANGES`, not also under `### Added`/etc.
   - **F-003**: `BREAKING CHANGE:` footer is now strict per Conventional Commits 1.0.0 §6 — only matches in the LAST paragraph (after a blank-line separator). Mid-body `BREAKING CHANGE:` no longer falsely promotes.
   - **F-004**: multiple `BREAKING CHANGE:` footers in one commit now each emit a separate breaking entry (was: only the first).
   - **F-005**: AC#3 + AC#5 tests strengthened with regex match-count assertions instead of substring-only.
   - **F-006**: 3 new edge-case tests (CRLF body, whitespace-only paragraph separator, mid-body `BREAKING CHANGE` without proper footer separator).

4. **Worked monorepo example** — `examples/monorepo/` runnable demo of `GIT_CHANGELOG_PATH` per-package CHANGELOG generation. Two packages, walkthrough README with setup → demo commits → update command → expected output → troubleshooting. Cross-link added from the existing `monorepo-workflow.md` config-composition guide.

## Closes

- #25 (release-it-preset doctor)
- #26 (configurable commit-type map + 4 followups F-002..F-006)

## Test plan

- [x] `pnpm test` — 433/433 passing (404 prior + 30 new doctor + 13 new changelog-types + 16 new for F-002..F-006 = +59 since v0.14.0)
  - Net delta vs `main` last green run: +59 unit tests
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm build` — exit 0
- [x] `pnpm exec biome check` — clean
- [x] `node bin/cli.js doctor --json` against the project itself — valid JSON with 4 sections
- [x] `node bin/cli.js doctor` — human output renders correctly
- [x] BREAKING CHANGE scenarios traced (footer, mid-body, multi-footer, bang)
- [x] Custom type map: env var > file > built-in priority verified

## Why minor (v0.15.0)

- **Doctor** is a new CLI command — additive, no breaking change.
- **Type-map** is opt-in — built-in default unchanged, new override paths.
- **F-002..F-006** are correctness fixes; the F-002 dedupe is technically observable behavior change but it removes spurious duplicate entries that users were already curating manually.
- **Monorepo example** is docs only.

Closes the v1.0 feature scope. Next: v1.0.0-rc.1 = freeze + OSS hygiene (CONTRIBUTING + CoC + README badges + API audit + exit code doc + manual e2e of hotfix/republish).

## File-by-file diff summary

```
.changelog-types.json            <-- new file, see scripts/lib/changelog-types.ts
bin/cli.js                       <-- +4: doctor entry + console.error fix
README.md                        <-- +64: doctor section + CHANGELOG_TYPE_MAP docs
examples/monorepo/**             <-- 13 files, 233 LOC: full runnable example
examples/monorepo-workflow.md    <-- +2: cross-link
scripts/doctor.ts                <-- new, 585 LOC, DI pattern, 4 categories
scripts/lib/changelog-types.ts   <-- new, 123 LOC, env > file > default loader
scripts/populate-unreleased-changelog.ts <-- F-002/F-003/F-004 applied
tests/unit/doctor.test.ts        <-- new, 30 tests
tests/unit/changelog-types.test.ts <-- new, 13 tests
tests/unit/populate-unreleased-changelog.test.ts <-- +16 tests for F-002..F-006
```
