### PR TITLE
chore: clarify changelog comments and test labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Multi-line commit body parser** — `populate-unreleased-changelog` now restricts conventional-commit scanning to the **header block** (lines before the first blank line), preventing paragraph-separated trailers like `Refs: #42`, `Co-authored-by:`, etc. from leaking as spurious `### Changed` entries. AC#5 multi-prefix on consecutive lines (`feat: x\nfix: y`) is preserved. Adds explicit `BREAKING CHANGE:` footer detection — promotes the first emitted part to breaking, or emits a standalone `misc` breaking entry when no leading conventional prefix is present. Closes [#23](https://github.com/oorabona/release-it-preset/issues/23). ([9ff76aa](https://github.com/oorabona/release-it-preset/commit/9ff76aa))
+- **Multi-line commit body parser** — `populate-unreleased-changelog` now restricts conventional-commit scanning to the **header block** (lines before the first blank line), preventing paragraph-separated trailers like `Refs: #42`, `Co-authored-by:`, etc. from leaking as spurious `### Changed` entries. Multi-prefix on consecutive lines (`feat: x\nfix: y`) is preserved. Adds explicit `BREAKING CHANGE:` footer detection — promotes the first emitted part to breaking, or emits a standalone `misc` breaking entry when no leading conventional prefix is present. Closes [#23](https://github.com/oorabona/release-it-preset/issues/23). ([9ff76aa](https://github.com/oorabona/release-it-preset/commit/9ff76aa))
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ All open work has been moved to GitHub issues for public visibility:
 - [x] ✅ Workflows OIDC parity — shipped v0.14.0 (PR #29 / `2b86ae8`, ci/hotfix/republish migrated, NPM_TOKEN secret obsolete)
 - [ ] 🚀 [#24](https://github.com/oorabona/release-it-preset/issues/24) v1.0.0 stability cycle (tracking checklist) — Priority: M (gated, drives beta.1 → rc.1 → stable)
 - [x] ✅ [#25](https://github.com/oorabona/release-it-preset/issues/25) `release-it-preset doctor` command — shipped v0.15.0 (PR #33)
-- [x] ✅ [#26](https://github.com/oorabona/release-it-preset/issues/26) Configurable commit-type → section mapping + 4 review followups F-002..F-006 — shipped v0.15.0 (PR #33)
+- [x] ✅ [#26](https://github.com/oorabona/release-it-preset/issues/26) Configurable commit-type → section mapping + 4 review-loop refinements (folded into #26) — shipped v0.15.0 (PR #33)
 - [x] ✅ [#31](https://github.com/oorabona/release-it-preset/issues/31) ci.yml malformed shell display step — shipped via chore PR #32 (jq unification)
 - [x] ✅ Dependabot alerts cleared — pnpm up -L + vite ^7.3.2 pin (devDeps only, no runtime impact, PR #32)
 - [ ] 🔧 [#30](https://github.com/oorabona/release-it-preset/issues/30) Extract smart dist-tag to composite action (DRY) — Priority: L (defer until 3rd caller, post-v1.0)

--- a/scripts/populate-unreleased-changelog.ts
+++ b/scripts/populate-unreleased-changelog.ts
@@ -115,8 +115,9 @@ export function parseCommitsWithMultiplePrefixes(
       // Compute the header block: first contiguous run of non-empty lines.
       // This prevents paragraph-separated footer tokens like "Refs: #42" or
       // "Co-authored-by: ..." from matching the conventional-commit regex
-      // via the 'gm' flag in extractConventionalCommitParts. AC#5 (consecutive
-      // multi-prefix lines) is preserved because those lines share no blank line.
+      // via the 'gm' flag in extractConventionalCommitParts. Consecutive
+      // multi-prefix lines (e.g. "feat: x\nfix: y") are preserved because
+      // they share no blank line — see #23 for the original use case.
       const headerBlock = body.split('\n').reduce(
         (acc, line) => {
           if (!acc.done) {
@@ -133,14 +134,14 @@ export function parseCommitsWithMultiplePrefixes(
 
       const parts = extractConventionalCommitParts(headerBlock, shortSha);
 
-      // F-003: Detect "BREAKING CHANGE:" trailers only in the LAST paragraph of the body,
+      // Detect "BREAKING CHANGE:" trailers only in the LAST paragraph of the body,
       // AND only when the body has more than one paragraph (i.e., there is at least one
       // blank-line separator). Per Conventional Commits 1.0.0 §6, a footer requires a
       // blank line separating it from the preceding content. A "BREAKING CHANGE:" that
       // appears on a line immediately after the subject line (no blank line) is mid-body
       // prose, NOT a footer, and must NOT promote the commit to breaking.
       //
-      // F-004: Use matchAll() so multiple BREAKING CHANGE: lines in the same last
+      // matchAll() is used so multiple BREAKING CHANGE: lines in the same last
       // paragraph each emit a separate breaking entry.
       // CRLF safety: accept both LF and CRLF line endings so commits authored on
       // Windows produce the same output (a paragraph separator can be \n\n or \r\n\r\n).
@@ -158,7 +159,7 @@ export function parseCommitsWithMultiplePrefixes(
         }
         // Each BREAKING CHANGE: footer line emits its own breaking entry with the
         // footer's description (distinct from the commit subject).
-        // F-004: Multiple footer lines → multiple entries.
+        // Multiple footer lines → multiple entries.
         for (const m of breakingFooterMatches) {
           parts.push({
             type: 'misc',
@@ -203,7 +204,7 @@ export function parseCommitsWithMultiplePrefixes(
   const breakingChanges: CommitPart[] = [];
 
   for (const part of allParts) {
-    // F-002: Breaking parts go ONLY into the BREAKING CHANGES section.
+    // Breaking parts go ONLY into the BREAKING CHANGES section.
     // They are NOT also added to their native section (e.g. ### Added), which
     // would produce duplicate entries. The breaking indicator in the native
     // section was confusing — the dedicated ### ⚠️ BREAKING CHANGES section

--- a/tests/unit/populate-unreleased-changelog.test.ts
+++ b/tests/unit/populate-unreleased-changelog.test.ts
@@ -247,8 +247,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect(result).not.toContain('[abc1234]')
     })
 
-    // AC#2 — multi-line body with paragraph-separated footer must NOT leak into CHANGELOG
-    it('AC#2: should not emit footer fragments (Refs:) as changelog entries', () => {
+    // multi-line body with paragraph-separated footer must NOT leak into CHANGELOG
+    it('should not emit footer fragments (Refs:) as changelog entries', () => {
       // The full body has a blank line separating the subject from the body paragraph,
       // and the "Refs:" footer trailer. Before the fix, "Refs: #42" matched the
       // conventional-commit regex and appeared as a spurious "### Changed" entry.
@@ -267,8 +267,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect(nonShaLines.join('\n')).not.toContain('#42')
     })
 
-    // AC#3 — BREAKING CHANGE: footer in body must promote first part to breaking
-    it('AC#3: should detect BREAKING CHANGE: footer and mark the commit as breaking', () => {
+    // BREAKING CHANGE: footer in body must promote first part to breaking
+    it('should detect BREAKING CHANGE: footer and mark the commit as breaking', () => {
       const gitOutput =
         'abc1234|feat: migrate config format\n\nUsers must update their config file.\nBREAKING CHANGE: config schema changed|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -279,8 +279,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect(result).not.toMatch(/^- BREAKING CHANGE/m)
     })
 
-    // AC#3 edge case — standalone BREAKING CHANGE footer with no leading conventional prefix
-    it('AC#3 edge: should emit standalone breaking entry when BREAKING CHANGE footer present but no conventional prefix', () => {
+    // edge case — standalone BREAKING CHANGE footer with no leading conventional prefix
+    it('should emit standalone breaking entry when BREAKING CHANGE footer present but no conventional prefix', () => {
       const gitOutput =
         'abc1234|Non-conventional subject line\n\nBREAKING CHANGE: removed the foo API|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -289,8 +289,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect(result).toContain('removed the foo API')
     })
 
-    // AC#4 — [skip-changelog] in a non-first body line must still trigger the skip
-    it('AC#4: should skip commit when [skip-changelog] appears in body paragraph (not first line)', () => {
+    // [skip-changelog] in a non-first body line must still trigger the skip
+    it('should skip commit when [skip-changelog] appears in body paragraph (not first line)', () => {
       const gitOutput =
         'abc1234|feat: internal refactor\n\nThis is an internal-only change.\n[skip-changelog]|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -298,8 +298,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect(result).toBe('No changes yet.')
     })
 
-    // AC#5 — consecutive multi-prefix lines (no blank line between) must produce 2 entries
-    it('AC#5: should emit two entries for consecutive conventional prefix lines with no blank line between', () => {
+    // consecutive multi-prefix lines (no blank line between) must produce 2 entries
+    it('should emit two entries for consecutive conventional prefix lines with no blank line between', () => {
       // No blank line between feat: and fix: — both are in the header block
       const gitOutput = 'abc1234|feat: add X\nfix: fix Y|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -600,7 +600,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
     })
   })
 
-  describe('F-002: breaking parts dedupe (only in BREAKING CHANGES, not in native section)', () => {
+  describe('breaking parts dedupe (only in BREAKING CHANGES, not in native section)', () => {
     it('bang-style breaking commit appears ONLY in BREAKING CHANGES, not in ### Added', () => {
       const gitOutput = 'abc1234567890|feat!: migrate config format|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -625,7 +625,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
     })
   })
 
-  describe('F-003: strict BREAKING CHANGE: footer (requires blank-line separation)', () => {
+  describe('strict BREAKING CHANGE: footer (requires blank-line separation)', () => {
     it('mid-body BREAKING CHANGE (no blank line) does NOT promote to breaking', () => {
       // No blank line between header and "BREAKING CHANGE:" — not a footer
       const gitOutput = 'abc1234567890|feat: x\nBREAKING CHANGE: not a footer|||END|||'
@@ -655,7 +655,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
     })
   })
 
-  describe('F-004: multi-footer BREAKING CHANGE (multiple lines in last paragraph)', () => {
+  describe('multi-footer BREAKING CHANGE (multiple lines in last paragraph)', () => {
     it('two BREAKING CHANGE lines in last paragraph emit two breaking entries', () => {
       const gitOutput =
         'abc1234567890|feat: big refactor\n\nBREAKING CHANGE: API changed\nBREAKING CHANGE: config changed|||END|||'
@@ -680,8 +680,8 @@ describe('populate-unreleased-changelog (with DI)', () => {
     })
   })
 
-  describe('F-005: entry-count locks on AC#3 and AC#5', () => {
-    it('AC#3 after F-002 dedupe: BREAKING CHANGE footer entry appears exactly once', () => {
+  describe('entry-count locks (regex match counts, not just substring)', () => {
+    it('BREAKING CHANGE footer entry appears exactly once after dedupe', () => {
       const gitOutput =
         'abc1234567890|feat: migrate config format\n\nUsers must update their config file.\nBREAKING CHANGE: config schema changed|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
@@ -690,7 +690,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
       expect((result.match(/migrate config format/g) ?? []).length).toBe(1)
     })
 
-    it('AC#5: two consecutive prefix lines emit exactly one entry each', () => {
+    it('two consecutive prefix lines emit exactly one entry each', () => {
       const gitOutput = 'abc1234567890|feat: add X\nfix: fix Y|||END|||'
       const result = parseCommitsWithMultiplePrefixes(gitOutput, 'https://github.com/owner/repo')
 
@@ -699,7 +699,7 @@ describe('populate-unreleased-changelog (with DI)', () => {
     })
   })
 
-  describe('F-006: edge cases (CRLF, whitespace-only separator, mid-body BREAKING CHANGE)', () => {
+  describe('edge cases (CRLF, whitespace-only separator, mid-body BREAKING CHANGE)', () => {
     it('CRLF line endings are handled correctly', () => {
       // Windows-style \r\n — blank line is \r\n\r\n
       const gitOutput = 'abc1234567890|feat: x\r\n\r\nbody\r\nRefs: #1|||END|||'


### PR DESCRIPTION
## Summary

Rename inline comment labels and test describe/it blocks to use plain-language descriptions or permanent identifiers (GitHub issue refs `#23`, `#26`) instead of session-local prefixes that would become dangling references over time.

## Why

Code comments and test labels should reference identifiers that survive the project lifespan. The previous prefixes were internal review-session-local labels — they only made sense to the people who shipped the original PR and stop being meaningful as soon as the next release ships.

Future contributors reading these comments cold won't know what those prefixes refer to. Plain technical descriptions (or links to the GH issue that frames the work) are self-explanatory.

Aligned with the rule documented at `~/.claude/memory/feedback_code_comments_no_process_artifacts.md`.

## Scope

| File | Change |
|---|---|
| `scripts/populate-unreleased-changelog.ts` | 4 inline comment blocks reworded to describe the technical rationale directly (header-block extraction, last-paragraph BREAKING CHANGE: footer detection per Conv. Commits 1.0.0 §6, matchAll multi-footer accumulation, CRLF safety, breaking-parts dedup). |
| `tests/unit/populate-unreleased-changelog.test.ts` | 11 `describe()` and `it()` block labels renamed to plain-English scenario names. Test bodies unchanged. |
| `TODO.md` | Closed-issue tail entry for `#26` reworded. |
| `CHANGELOG.md` | v0.13.0 entry's "multi-prefix on consecutive lines" sentence reworded. |

## Out of scope

- npm tarballs of v0.13.0..v0.15.0 are immutable and keep their original copy of `CHANGELOG.md`. Only `main` text is updated going forward.
- `docs/archive/TODO-2025-Q4.md` historical phase markers — intentional record, kept as-is.

## Test plan

- [x] `pnpm test` — 435/435 passing (no behavior change)
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm build` — exit 0
- [ ] CI green

## No version bump

This is a documentation/labels cleanup. No runtime change. No new release.
