### PR TITLE
feat: v1.0.0-rc.1 — peer drop, OSS hygiene, public API, doctor workspace detection

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at olivier.orabona@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Thanks for your interest. This project values small, focused PRs with clear test
 git clone https://github.com/oorabona/release-it-preset
 cd release-it-preset
 pnpm install
-pnpm test          # 435 tests should pass
+pnpm test          # 439+ tests should pass
 pnpm exec tsc --noEmit
 pnpm build
 ```
@@ -42,7 +42,7 @@ chore: clarify changelog comments and test labels
 Run all four locally before opening a PR:
 
 ```bash
-pnpm test                          # vitest, expect 435+ passing
+pnpm test                          # vitest, expect 439+ passing
 pnpm exec tsc --noEmit             # type check
 pnpm exec biome check --write .    # lint + format
 pnpm build                         # compile dist/scripts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to `@oorabona/release-it-preset`
+
+Thanks for your interest. This project values small, focused PRs with clear test coverage and Conventional Commits hygiene.
+
+## Quick start
+
+```bash
+git clone https://github.com/oorabona/release-it-preset
+cd release-it-preset
+pnpm install
+pnpm test          # 435 tests should pass
+pnpm exec tsc --noEmit
+pnpm build
+```
+
+Requirements: Node ≥ 20, pnpm ≥ 10. The project is ESM-only.
+
+## Development setup
+
+Source lives in TypeScript (`scripts/*.ts`) and is compiled to `dist/scripts/` via `pnpm build`. The CLI (`bin/cli.js`) is plain JS with no build step. Configuration files in `config/` are also plain JS modules.
+
+The compiled `dist/` is committed via `prepublishOnly`; you do not need to commit it manually.
+
+## Branching & commit conventions
+
+- Branch prefixes: `feat/`, `fix/`, `refactor/`, `docs/`, `chore/`. Use kebab-case for the rest of the name (e.g., `fix/multi-line-body-parser`).
+- Commits **must** follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). The format is enforced by a commit-msg hook.
+- Commit titles ≤ 80 characters. Body wraps ~72 characters.
+- Reference issues with `Closes #N` / `Refs #N` in the commit body or PR description.
+
+Examples:
+
+```text
+feat(doctor): add diagnostic command (#25)
+fix(changelog): stop footer lines leaking into CHANGELOG (issue #23)
+refactor(workflows): migrate ci/hotfix/republish to npm OIDC trusted publishing
+chore: clarify changelog comments and test labels
+```
+
+## Pre-PR checklist
+
+Run all four locally before opening a PR:
+
+```bash
+pnpm test                          # vitest, expect 435+ passing
+pnpm exec tsc --noEmit             # type check
+pnpm exec biome check --write .    # lint + format
+pnpm build                         # compile dist/scripts
+```
+
+Then run the project's own diagnostic on your fork:
+
+```bash
+node bin/cli.js doctor
+```
+
+A `WARNINGS` status is fine for an in-progress branch; `BLOCKED` is not.
+
+If you touched user-facing behavior, add or update an entry under `[Unreleased]` in `CHANGELOG.md`. The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) (Added/Changed/Fixed/Removed/Security/⚠️ BREAKING CHANGES).
+
+If your commit is purely internal (CI tweaks, refactors with no observable surface change), add `[skip-changelog]` in the commit body to skip the changelog automation.
+
+## Testing conventions
+
+- Unit tests live in `tests/unit/`. Use the Dependency Injection pattern (`vi.fn()` for `execSync`/`readFileSync`/`getEnv`); no mocking of the `node:fs` or `node:child_process` modules themselves.
+- Integration tests in `tests/integration/` exercise the CLI dispatch.
+- E2E tests in `tests/e2e/` spawn the actual CLI against a temp git repo (testcontainers-style).
+- Real fixtures preferred over mocks of internal pure functions.
+- Coverage threshold is informal but new code should have happy-path + at least one error-path test.
+
+## Architecture quick tour
+
+For the full project layout, see [`CLAUDE.md`](./CLAUDE.md). The 30-second tour:
+
+- `bin/cli.js` — CLI entry, dispatches `release-it-preset <command>` to either a release config (spawn release-it) or a utility script.
+- `config/*.js` — 7 release-it preset configurations (`default`, `hotfix`, `manual-changelog`, `no-changelog`, `republish`, `retry-publish`, `changelog-only`). All compose from `base-config.js` builders.
+- `scripts/*.ts` — utility scripts (DI pattern). The dispatch table is in `bin/cli.js`'s `UTILITY_COMMANDS`.
+- `scripts/lib/*.ts` — pure helpers (git utilities, commit parser, semver, error classes, type-map loader).
+- `.github/workflows/*.yml` — reusable GHA workflows (`publish.yml` for OIDC trusted publishing, `audit.yml`, `ci.yml`, `hotfix.yml`, `republish.yml`, `validate-pr.yml`, `reusable-verify.yml`, `build-dist.yml`).
+
+## Reporting issues
+
+[Open a GitHub issue](https://github.com/oorabona/release-it-preset/issues). Include:
+
+- The exact command that failed and its full output (use `release-it-preset doctor --json` for environment details).
+- The version (`pnpm exec release-it-preset --help` shows it).
+- A minimal reproduction if behavioral.
+
+For security concerns, please email olivier.orabona@gmail.com directly rather than opening a public issue. See [`SECURITY.md`](./SECURITY.md) for the disclosure policy.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md) (Contributor Covenant 2.1).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -2,18 +2,49 @@
 
 Shared [release-it](https://github.com/release-it/release-it) configuration and scripts for automated versioning, changelog generation, and package publishing.
 
-[![codecov](https://codecov.io/github/oorabona/release-it-preset/graph/badge.svg?token=6RMN34Z7TX)](https://codecov.io/github/oorabona/release-it-preset)
+[![NPM Version](https://img.shields.io/npm/v/@oorabona/release-it-preset.svg)](https://npmjs.org/package/@oorabona/release-it-preset)
+[![NPM Downloads](https://img.shields.io/npm/dm/@oorabona/release-it-preset.svg)](https://npmjs.org/package/@oorabona/release-it-preset)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node](https://img.shields.io/node/v/@oorabona/release-it-preset.svg)](https://nodejs.org/)
+[![OIDC trusted publishing](https://img.shields.io/badge/npm-OIDC%20trusted%20publishing-green.svg)](https://docs.npmjs.com/trusted-publishers)
 [![CI](https://github.com/oorabona/release-it-preset/actions/workflows/ci.yml/badge.svg)](https://github.com/oorabona/release-it-preset/actions/workflows/ci.yml)
 [![Audit](https://github.com/oorabona/release-it-preset/actions/workflows/audit.yml/badge.svg)](https://github.com/oorabona/release-it-preset/actions/workflows/audit.yml)
-[![NPM Version](https://img.shields.io/npm/v/release-it-preset.svg)](https://npmjs.org/package/@oorabona/release-it-preset)
-[![NPM Downloads](https://img.shields.io/npm/dm/release-it-preset.svg)](https://npmjs.org/package/@oorabona/release-it-preset)
+[![codecov](https://codecov.io/github/oorabona/release-it-preset/graph/badge.svg?token=6RMN34Z7TX)](https://codecov.io/github/oorabona/release-it-preset)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.3+-blue.svg)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Why this preset?
+
+Most release workflows fall into one of three traps: too much manual work (plain release-it, you assemble everything), too much ceremony (changesets, great for 5+ maintainers, heavy for one), or too much automation with too little control (semantic-release, hands-off by design and format).
+
+`@oorabona/release-it-preset` occupies the productive middle ground for solo and small-team JavaScript package maintainers who want:
+
+- **Human-readable changelogs.** Keep a Changelog format (Added/Fixed/Changed/Removed/Security) generated automatically from conventional commits — no manual entry writing, no machine-format diffs.
+- **OIDC publishing without CI plumbing.** Import the reusable `publish.yml` workflow in three lines. OIDC trusted publishing with npm provenance ships on day one, no `NPM_TOKEN` secret required.
+- **Diagnostic confidence before release.** Run `release-it-preset doctor` to surface every misconfiguration — git auth, npm auth, changelog hygiene, branch requirements — before anything breaks in CI.
+- **Recovery presets for the real world.** Dedicated `republish` and `retry-publish` configs handle the scenarios other tools pretend don't happen.
+
+**Pick this preset** if you maintain one or a few npm packages, write Keep a Changelog, deploy from GitHub Actions, and want pre-built OIDC publishing without adopting changesets or semantic-release's philosophy.
+
+**Do not pick this preset** if you have a large monorepo with cross-package dependency management needs (use [changesets](https://github.com/changesets/changesets)) or if you want zero human involvement in versioning decisions (use [semantic-release](https://github.com/semantic-release/semantic-release)).
+
+## Ecosystem positioning
+
+| Tool | Strength | When to prefer it |
+|---|---|---|
+| **`@oorabona/release-it-preset`** (this) | Keep a Changelog discipline + OIDC workflows + `doctor` CLI + recovery presets | Solo / small-team JS maintainer, human-curated changelogs, GitHub Actions CI |
+| [release-it](https://github.com/release-it/release-it) (plain) | Maximum flexibility, smallest opinion footprint | You want to assemble each piece yourself |
+| [changesets](https://github.com/changesets/changesets) | PR-driven versioning, fixed/linked package versions | 5+ maintainer monorepo, every change deserves explicit intent |
+| [semantic-release](https://github.com/semantic-release/semantic-release) | Fully-automated, zero human intervention | Branch-driven release pipelines, no human review of changelogs |
+| [release-please](https://github.com/googleapis/release-please) | GitHub Release PR pattern, 20+ language strategies | Polyglot repos, GitHub-native PR-driven workflow |
+| [`@release-it-plugins/workspaces`](https://github.com/release-it-plugins/workspaces) | Multi-package iteration + cross-pkg dep sync | Monorepo with bulk publish — composes with this preset (see [Composing with `@release-it-plugins/workspaces`](#composing-with-release-it-pluginsworkspaces)) |
 
 ## Table of Contents
 
+- [Why this preset?](#why-this-preset)
+- [Ecosystem positioning](#ecosystem-positioning)
 - [Features](#features)
 - [Installation](#installation)
+  - [Install patterns](#install-patterns)
 - [Quick Start](#quick-start)
 - [Available Configurations](#available-configurations)
 - [CLI Usage](#cli-usage)
@@ -21,6 +52,7 @@ Shared [release-it](https://github.com/release-it/release-it) configuration and 
   - [Preset Selection Mode](#preset-selection-mode)
   - [Passthrough Mode (Custom Config Override)](#passthrough-mode-custom-config-override)
   - [Monorepo Support](#monorepo-support)
+  - [Composing with `@release-it-plugins/workspaces`](#composing-with-release-it-pluginsworkspaces)
   - [Utility Commands](#utility-commands)
 - [Scripts](#scripts)
 - [Environment Variables](#environment-variables)
@@ -30,8 +62,11 @@ Shared [release-it](https://github.com/release-it/release-it) configuration and 
 - [GitHub Actions Workflows](#github-actions-workflows)
   - [Reusable Workflows](#reusable-workflows)
   - [Workflow Reference](#workflow-reference)
+- [Exit codes](#exit-codes)
 - [Best Practices](#best-practices)
 - [Troubleshooting](#troubleshooting)
+- [Public API](#public-api)
+- [Contributing](#contributing)
 
 ## Features
 
@@ -52,6 +87,20 @@ Shared [release-it](https://github.com/release-it/release-it) configuration and 
 ```bash
 pnpm add -D @oorabona/release-it-preset release-it
 ```
+
+### Install patterns
+
+| Use case | Command | Notes |
+|---|---|---|
+| **Try without installing** | `pnpm dlx @oorabona/release-it-preset doctor` | Fetch + run, no install. Use for evaluating the preset on an existing repo. |
+| **One-shot npx** | `npx -y @oorabona/release-it-preset doctor` | Same idea, npm-flavored |
+| **Adopt as devDep** (recommended) | `pnpm add -D @oorabona/release-it-preset release-it` | Pins via lockfile, idiomatic for projects |
+| **CI usage** | `pnpm install --frozen-lockfile && pnpm exec release-it-preset retry-publish --ci` | Lockfile-deterministic, no prompts |
+| **Diagnostic on any repo** | `pnpm dlx @oorabona/release-it-preset doctor` | Works against the cwd's git/package.json/CHANGELOG; great for quick health checks |
+
+**Global install is not recommended** — pin per-project for reproducibility. The preset is small (<20KB unpacked); CI overhead is negligible.
+
+The peer requirement is `release-it ^19.0.0 || ^20.0.0`. Both versions are tested. v20 is recommended for the OIDC trusted publishing handshake (npm ≥ 11.5.1, Node ≥ 24); v19 is supported for composing with [`@release-it-plugins/workspaces`](#composing-with-release-it-pluginsworkspaces) (its peer maxes at v19 today).
 
 ## Quick Start
 
@@ -476,7 +525,37 @@ pnpm release-it-preset --config .release-it-manual.json
 - Multiple validation layers prevent abuse
 - No privilege escalation in CLI tool context
 
-See [examples/monorepo-workflow.md](examples/monorepo-workflow.md) for complete monorepo guide.
+See [examples/monorepo-workflow.md](examples/monorepo-workflow.md) for complete monorepo guide and [examples/monorepo/](examples/monorepo/) for a runnable workspace demo.
+
+### Composing with `@release-it-plugins/workspaces`
+
+This preset focuses on a single package per release-it run. If your monorepo needs **bulk publish** (iterate over every workspace package + sync cross-package dependency versions), compose this preset with [`@release-it-plugins/workspaces`](https://github.com/release-it-plugins/workspaces) — the canonical release-it plugin for that workflow.
+
+```bash
+# Install both
+pnpm add -D @oorabona/release-it-preset @release-it-plugins/workspaces release-it@^19
+```
+
+```jsonc
+// .release-it.json — extends our preset AND loads the workspaces plugin
+{
+  "extends": "@oorabona/release-it-preset/config/default",
+  "plugins": {
+    "@release-it-plugins/workspaces": true
+  }
+}
+```
+
+**Peer compatibility note:** `@release-it-plugins/workspaces` v5.0.3 declares peer `release-it ^17 || ^18 || ^19`. Our preset declares peer `^19 || ^20`. The intersection is `^19`, so when composing with the workspaces plugin you must pin release-it to v19. v20 standalone (without the workspaces plugin) is fully supported and recommended for new projects.
+
+`release-it-preset doctor` does **not** check whether the workspaces plugin is loaded — it's an opt-in composition. Run it manually after install if you want to verify the plugin's own preflight checks.
+
+When this composition is right for you:
+- You release multiple packages from one repo with **synchronized versions** (all bumped together).
+- You want **cross-package dependency sync** (when `pkg-a` bumps to 2.0, `pkg-b`'s reference auto-updates).
+
+When our preset alone is enough:
+- **Independent versioning** per package (each package releases when ready). Use `GIT_CHANGELOG_PATH=packages/<pkg>` to scope the CHANGELOG. See [examples/monorepo/](examples/monorepo/) for the runnable demo.
 
 ### Utility Commands
 
@@ -1533,11 +1612,30 @@ Common issues:
 
 This can appear if you interrupt a release, tweak `CHANGELOG.md`, then retry with the same version. The preset automatically passes `--allow-same-version` to `npm version`, so simply re-run `pnpm release` (or `pnpm release-it-preset default --retry`) and select the same version—`npm` will no longer abort.
 
+## Exit codes
+
+The CLI follows this convention (stable from v1.0.0 onward):
+
+| Code | Meaning | Examples |
+|---|---|---|
+| `0` | Success | Command completed; for `doctor`, `READY` or `WARNINGS` status |
+| `1` | General failure | Unhandled error, validation failure, `doctor` `BLOCKED` status |
+| `2` | Precondition failure (CI-friendly) | `validate` reports CHANGELOG missing or `[Unreleased]` empty |
+| `3..9` | **Reserved** | Not currently emitted; reserved for future contract additions |
+
+In CI scripts, distinguish `exit 1` (try-again-friendly) from `exit 2` (precondition not met — require operator action) when chaining commands.
+
+## Public API
+
+The full **stable surface** (CLI commands, environment variables, config exports, GHA workflow inputs, exit codes) is documented in [`docs/PUBLIC_API.md`](docs/PUBLIC_API.md). Items not listed there are internal and may change in any version.
+
 ## License
 
-MIT
+MIT — see [`LICENSE`](LICENSE).
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or pull request.
+PRs and issues welcome. Please read [`CONTRIBUTING.md`](CONTRIBUTING.md) before opening a pull request — it covers the Conventional Commits requirement, branch prefixes, the pre-PR checklist, and the testing conventions. By participating you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) (Contributor Covenant 2.1).
+
+For security concerns, please email `olivier.orabona@gmail.com` directly rather than opening a public issue. See [`SECURITY.md`](SECURITY.md) for the disclosure policy.
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ pnpm add -D @oorabona/release-it-preset release-it
 
 **Global install is not recommended** — pin per-project for reproducibility. The preset is small (<20KB unpacked); CI overhead is negligible.
 
-The peer requirement is `release-it ^19.0.0 || ^20.0.0`. Both versions are tested. v20 is recommended for the OIDC trusted publishing handshake (npm ≥ 11.5.1, Node ≥ 24); v19 is supported for composing with [`@release-it-plugins/workspaces`](#composing-with-release-it-pluginsworkspaces) (its peer maxes at v19 today).
+The peer requirement is `release-it ^19.0.0 || ^20.0.0`. CI runs against the upper bound (v20.x) on every commit; v19 was smoke-tested manually before the constraint was widened. v20 is recommended for the OIDC trusted publishing handshake (npm ≥ 11.5.1, Node ≥ 24); v19 is supported for composing with [`@release-it-plugins/workspaces`](#composing-with-release-it-pluginsworkspaces) (its peer maxes at v19 today).
 
 ## Quick Start
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -144,15 +144,17 @@ No existing configuration is affected. Both vars require explicit opt-in.
 
 ---
 
-## Upgrade checklist for v1.0.0 (preview)
+## Upgrade checklist for v1.0.0
 
-v1.0 will freeze the public API surface: config export paths, CLI commands
-and flags, environment variable names, exit codes, and the `extends` contract.
-No additional breaking changes are planned beyond what v0.10 already shipped.
+v1.0 freezes the public API surface: config export paths, CLI commands and
+flags, environment variable names, exit codes, and the `extends` contract.
+The full surface is documented in [`docs/PUBLIC_API.md`](./PUBLIC_API.md).
 
-Before v1.0.0 stable is tagged, a `v1.0.0-beta.1` will be published.
-Integrators should test against the beta and report any contract concerns
-as issues before the stable release.
+The path to v1.0.0 stable runs `v0.13.0` (multi-line body parser fix) →
+`v0.14.0` (workflows OIDC parity) → `v0.15.0` (doctor + configurable
+commit-type-map) → `v1.0.0-rc.1` (freeze + OSS hygiene + announce) →
+`v1.0.0` stable. There is **no `beta` phase** — integrators concerned about
+the contract should test against `v1.0.0-rc.1`.
 
 Once v1.0.0 is out, standard semver discipline applies: breaking changes
 require a major version bump. The v0.x series does not provide a formal
@@ -165,7 +167,41 @@ backport policy.
       v0.10.0)
 - [ ] Verify commit-msg hooks accept `chore(release): v${version}` (default
       since v0.10.1)
-- [ ] Audit any env vars you set against the current reference in `README.md`
-      and `CLAUDE.md` — names have been stable since v0.7.0
-- [ ] Run `release-it-preset check` to confirm the preset resolves correctly
-      in your environment
+- [ ] Audit any env vars you set against [`docs/PUBLIC_API.md`](./PUBLIC_API.md)
+      — names have been stable since v0.7.0
+- [ ] Run `release-it-preset doctor` (new in v0.15.0) to confirm the preset
+      resolves correctly in your environment
+
+## v1.0 stability commitments
+
+The contract listed in [`docs/PUBLIC_API.md`](./PUBLIC_API.md) is what we
+freeze in v1.0.0. To recap:
+
+- **Stable**: 7 release configs (`default`/`hotfix`/`changelog-only`/
+  `manual-changelog`/`no-changelog`/`republish`/`retry-publish`), 7 utility
+  commands (`init`/`update`/`validate`/`check`/`doctor`/`check-pr`/
+  `retry-publish-preflight`), 18 environment variables (17 in
+  `ENV_VAR_CATALOG` + `CHANGELOG_TYPE_MAP`), 7 config exports under
+  `@oorabona/release-it-preset/config/*`, the `publish.yml` workflow input
+  contract, and the `release-it ^19 || ^20` peer dep range.
+- **Internal** (may change without notice): `scripts/lib/*`, individual
+  script exports beyond the CLI surface, `dist/types/*`, DI dependency
+  interfaces, the `bin/validators.js` internals.
+
+If a future release needs to touch any stable item, it requires a major
+version bump (`v2.0.0`).
+
+## Exit code stability
+
+CLI exit codes follow this convention from v1.0.0 onward:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success (`doctor` `READY` or `WARNINGS` status; commands completed) |
+| `1` | General failure (unhandled error, validation failure, `doctor` `BLOCKED` status) |
+| `2` | Precondition failure for CI (`validate` reports CHANGELOG missing or `[Unreleased]` empty) |
+| `3..9` | **Reserved** — not currently emitted; reserved for future contract additions |
+
+Scripts use a typed error hierarchy (`ScriptError` / `ValidationError` /
+`GitError` / `ChangelogError`) under the hood; the typed errors are
+internal but the exit-code contract above is stable.

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -88,6 +88,19 @@ These env vars are read by configs and scripts. Setting them overrides built-in 
 | `GITHUB_RELEASE` | `false` | Set to `true` to create a GitHub Release |
 | `GITHUB_REPOSITORY` | _(unset, auto-detected from git remote)_ | `owner/repo` for commit/release links |
 
+### Hotfix
+
+| Name | Default | Notes |
+|---|---|---|
+| `HOTFIX_INCREMENT` | `patch` | Version increment for the `hotfix` config (`patch`/`minor`/`major`/`prepatch`/`preminor`/`premajor`/`prerelease`) |
+
+### `check-pr` utility
+
+| Name | Default | Notes |
+|---|---|---|
+| `PR_BASE_REF` | _(falls back to `GITHUB_BASE_REF` then `origin/main`)_ | Base ref for the PR diff (used by `release-it-preset check-pr`) |
+| `PR_HEAD_REF` | _(falls back to `GITHUB_HEAD_REF` then `HEAD`)_ | Head ref for the PR diff |
+
 ### Project file (lower priority than `CHANGELOG_TYPE_MAP` env var)
 
 | File | Notes |
@@ -154,13 +167,13 @@ Scripts use `ScriptError`/`ValidationError`/`GitError`/`ChangelogError` (typed e
 The following are **NOT** stable. Do not depend on their shape, location, or behavior across versions:
 
 - `scripts/lib/*` (helper modules: `git-utils`, `commit-parser`, `semver-utils`, `string-utils`, `changelog-types`, `errors`, `run-script`)
-- Individual `scripts/<command>.ts` exports beyond the CLI surface (e.g., importing `populateChangelog(deps)` directly from `dist/scripts/populate-unreleased-changelog.js`)
+- **Individual `scripts/<command>.ts` exports beyond the CLI surface** — `package.json` exports `./scripts/*` to expose `dist/scripts/*.js`, but consuming those modules programmatically (e.g., `import { populateChangelog } from '@oorabona/release-it-preset/scripts/populate-unreleased-changelog'`) is **exported-but-unstable**: the module-level exports may rename, change signatures, or move between minor versions. Use the CLI commands (`release-it-preset update`, etc.) for stable behavior.
 - TypeScript declaration files in `dist/types/*` — emitted for editor experience, signature shapes may evolve
 - `bin/validators.js` internals (validators are still applied to user input but their function signatures may change)
 - The DI dependency interfaces (`PopulateChangelogDeps`, `GitDeps`, `DoctorDeps`, etc.) — used internally for testing
 - The repo layout under `dist/` beyond `dist/scripts/` and `dist/types/`
 
-If you find yourself importing from `scripts/lib/*.js` or `dist/types/*` directly, you have stepped outside the stable API. Open an issue requesting the surface area you need and we can promote it to stable in a minor version.
+If you find yourself importing from `scripts/lib/*.js`, `dist/types/*`, or `@oorabona/release-it-preset/scripts/*` programmatically, you have stepped outside the stable API. Open an issue requesting the surface area you need and we can promote it to stable in a minor version.
 
 ---
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,0 +1,185 @@
+# Public API Surface — `@oorabona/release-it-preset`
+
+This document defines what is **stable** in v1.0 (semver-protected) versus **internal** (subject to change without a major version bump). It is the contract you can rely on.
+
+## Versioning policy (post-v1.0)
+
+| Change kind | Version bump | Examples |
+|---|---|---|
+| Bug fix, doc update, transitive dep bump (internal) | `v1.0.x` (patch) | Fix a parser edge case, fix a typo, bump vitest |
+| New stable item (additive) | `v1.x.0` (minor) | New utility command, new env var, new release config preset, new field on existing preset |
+| Remove or rename a stable item; change semantic of a stable item; broaden allowed exit-code range | `v2.0.0` (major) | Drop a CLI command, rename an env var, change a preset's default behavior |
+
+**Stable items are listed below. Anything not listed is internal and may change in any version.**
+
+---
+
+## Stable CLI commands
+
+The `release-it-preset` binary (or `pnpm release-it-preset`) accepts these commands. All are documented in the README's CLI section and tested against the published surface.
+
+### Release commands (spawn `release-it` with the matching config)
+
+| Command | Config file | Use case |
+|---|---|---|
+| `default` | `config/default.js` | Standard release: changelog auto-population + git + GitHub + npm |
+| `hotfix` | `config/hotfix.js` | Emergency patch; changelog generated from commits |
+| `changelog-only` | `config/changelog-only.js` | Update CHANGELOG only; no version bump or release |
+| `manual-changelog` | `config/manual-changelog.js` | Release with already-curated `[Unreleased]` content |
+| `no-changelog` | `config/no-changelog.js` | Release without touching CHANGELOG |
+| `republish` | `config/republish.js` | Move existing tag and re-release (`I understand the risks` workflow) |
+| `retry-publish` | `config/retry-publish.js` | Retry failed npm/GitHub publish without git operations |
+
+### Utility commands (run dedicated scripts)
+
+| Command | Script | Use case |
+|---|---|---|
+| `init` | `init-project` | Bootstrap CHANGELOG.md + `.release-it.json` extends |
+| `update` | `populate-unreleased-changelog` | Fill `[Unreleased]` from commits since last tag |
+| `validate` | `validate-release` | Pre-release readiness check (exit 2 on precondition failure) |
+| `check` | `check-config` | Verbose dump of env vars + git/npm state |
+| `doctor` | `doctor` | Structured diagnostic: 4-section checklist + `--json` output, exit 1 on BLOCKED |
+| `check-pr` | `check-pr-status` | PR hygiene checks for GitHub Actions consumption |
+| `retry-publish-preflight` | `retry-publish` (preflight mode) | Pre-flight checks before retry-publish runs |
+
+All commands accept `--ci`, `--dry-run`, `--increment <patch\|minor\|major>`, `--preRelease <id>` flags pass-through to `release-it` (release commands) or interpreted by the script (utility commands).
+
+---
+
+## Stable environment variables
+
+These env vars are read by configs and scripts. Setting them overrides built-in defaults. Unset = default.
+
+### Changelog
+
+| Name | Default | Notes |
+|---|---|---|
+| `CHANGELOG_FILE` | `CHANGELOG.md` | Path to changelog file |
+| `GIT_CHANGELOG_PATH` | _(unset)_ | Repository-relative path to scope `git log` (monorepo per-package CHANGELOG); validated against absolute paths, `..` traversal, shell metacharacters |
+| `GIT_CHANGELOG_SINCE` | _(unset)_ | Override the `since` baseline (any git ref: SHA, tag, branch); bypasses per-package release-commit detection and `git describe --tags` fallback |
+| `GIT_CHANGELOG_COMMAND` | _(unset)_ | Override the `git log` command used for release-it's release-preview |
+| `GIT_CHANGELOG_DESCRIBE_COMMAND` | `git describe --tags --abbrev=0` | Override the latest-tag detection command |
+| `CHANGELOG_TYPE_MAP` | _(unset)_ | JSON string overriding the built-in commit-type → CHANGELOG section map. Highest priority (overrides `.changelog-types.json` file and built-in defaults). Example: `{"deps":"### Dependencies"}` |
+
+### Git
+
+| Name | Default | Notes |
+|---|---|---|
+| `GIT_COMMIT_MESSAGE` | `release: bump v${version}` | Release commit template |
+| `GIT_TAG_NAME` | `v${version}` | Tag template |
+| `GIT_REQUIRE_BRANCH` | `main` | Required branch for releases |
+| `GIT_REQUIRE_UPSTREAM` | `false` | Require upstream tracking (`true`/`false`) |
+| `GIT_REQUIRE_CLEAN` | `false` | Require clean working tree |
+| `GIT_REMOTE` | `origin` | Git remote name |
+
+### npm
+
+| Name | Default | Notes |
+|---|---|---|
+| `NPM_PUBLISH` | `false` | Set to `true` to enable `npm publish` (off-by-default for safety) |
+| `NPM_SKIP_CHECKS` | `false` | Skip `npm whoami` precheck (set to `true` under OIDC trusted publishing) |
+| `NPM_ACCESS` | `public` | npm `--access` value |
+| `NPM_TAG` | _(unset)_ | When set, appended as `--tag <value>` to npm publish (used by smart dist-tag selection in `publish.yml`) |
+
+### GitHub
+
+| Name | Default | Notes |
+|---|---|---|
+| `GITHUB_RELEASE` | `false` | Set to `true` to create a GitHub Release |
+| `GITHUB_REPOSITORY` | _(unset, auto-detected from git remote)_ | `owner/repo` for commit/release links |
+
+### Project file (lower priority than `CHANGELOG_TYPE_MAP` env var)
+
+| File | Notes |
+|---|---|
+| `.changelog-types.json` | Project-level commit-type → CHANGELOG section map override. Resolution: env var > this file > built-in defaults. |
+
+---
+
+## Stable config exports
+
+The package exports release-it preset configs that you can `extends` from your `.release-it.json`:
+
+```json
+{
+  "extends": "@oorabona/release-it-preset/config/default"
+}
+```
+
+| Export path | Maps to |
+|---|---|
+| `@oorabona/release-it-preset/config/default` | `config/default.js` |
+| `@oorabona/release-it-preset/config/hotfix` | `config/hotfix.js` |
+| `@oorabona/release-it-preset/config/changelog-only` | `config/changelog-only.js` |
+| `@oorabona/release-it-preset/config/manual-changelog` | `config/manual-changelog.js` |
+| `@oorabona/release-it-preset/config/no-changelog` | `config/no-changelog.js` |
+| `@oorabona/release-it-preset/config/republish` | `config/republish.js` |
+| `@oorabona/release-it-preset/config/retry-publish` | `config/retry-publish.js` |
+
+The shape of each exported config object is the standard release-it config schema; we add no custom fields beyond what release-it documents.
+
+---
+
+## Stable GitHub Actions workflows
+
+Reusable workflows under `.github/workflows/` are publishable surface (importable via `workflow_call`). The publish surface is:
+
+| Workflow | Inputs | Notes |
+|---|---|---|
+| `publish.yml` | `tag`, `npm_only`, `github_only`, `dist_tag` | npm OIDC trusted publishing + GitHub release. Triggered on `push: tags v*`, `workflow_call`, `workflow_dispatch`. |
+
+Workflow internals (job structure, step ordering, `runs-on`) may change in any version. The **inputs** are the contract.
+
+---
+
+## Exit code stability
+
+CLI exit codes follow this convention:
+
+| Code | Meaning | Examples |
+|---|---|---|
+| `0` | Success | Command completed; for `doctor`, `READY` or `WARNINGS` status |
+| `1` | General failure | Unhandled error, validation failure, `doctor` `BLOCKED` status |
+| `2` | Precondition failure (CI-friendly) | `validate` reports CHANGELOG missing or `[Unreleased]` empty |
+| `3..9` | **Reserved** | Not currently used; reserved for future contract additions |
+
+Scripts use `ScriptError`/`ValidationError`/`GitError`/`ChangelogError` (typed error hierarchy in `scripts/lib/errors.ts`) to differentiate failure modes; the typed error is internal but the exit-code contract above is stable.
+
+**Breaking change in a future major would** introduce semantic for codes 3-9 OR change the meaning of 0/1/2.
+
+---
+
+## Internal — subject to change
+
+The following are **NOT** stable. Do not depend on their shape, location, or behavior across versions:
+
+- `scripts/lib/*` (helper modules: `git-utils`, `commit-parser`, `semver-utils`, `string-utils`, `changelog-types`, `errors`, `run-script`)
+- Individual `scripts/<command>.ts` exports beyond the CLI surface (e.g., importing `populateChangelog(deps)` directly from `dist/scripts/populate-unreleased-changelog.js`)
+- TypeScript declaration files in `dist/types/*` — emitted for editor experience, signature shapes may evolve
+- `bin/validators.js` internals (validators are still applied to user input but their function signatures may change)
+- The DI dependency interfaces (`PopulateChangelogDeps`, `GitDeps`, `DoctorDeps`, etc.) — used internally for testing
+- The repo layout under `dist/` beyond `dist/scripts/` and `dist/types/`
+
+If you find yourself importing from `scripts/lib/*.js` or `dist/types/*` directly, you have stepped outside the stable API. Open an issue requesting the surface area you need and we can promote it to stable in a minor version.
+
+---
+
+## How to know if a change broke the contract
+
+Before publishing a major or minor version:
+
+1. Run `pnpm exec release-it-preset doctor --json` against a fresh checkout of the release tag — should produce the same shape.
+2. Verify each `RELEASE_CONFIG` entry in `bin/cli.js` resolves to a file present in `config/`.
+3. Verify each `UTILITY_COMMAND` entry resolves to a script present in `dist/scripts/`.
+4. Verify the env-var catalog in `scripts/doctor.ts` (`ENV_VAR_CATALOG`) matches the list in this document.
+5. Verify the workflow input contract in `publish.yml` is unchanged.
+
+If any of (2), (3), (4), (5) require a contract change, that's a major version bump.
+
+---
+
+## See also
+
+- [Versioning notes in MIGRATION.md](./MIGRATION.md) for version-by-version breaking changes (pre-v1.0 era).
+- [README — Why this preset?](../README.md#why-this-preset) for the positioning narrative.
+- [CONTRIBUTING.md](../CONTRIBUTING.md) for how to propose new stable items.

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "prepublishOnly": "pnpm build && echo 'Running prepublish checks...' && test -f README.md && test -f LICENSE"
   },
   "peerDependencies": {
-    "release-it": "^20.0.0"
+    "release-it": "^19.0.0 || ^20.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "vitest": "^4.1.5"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.19.0"
   },
   "packageManager": "pnpm@10.17.1"
 }

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -288,6 +288,54 @@ export function inspectRepository(deps: DoctorDeps): RepositorySection {
 // 3. Configuration
 // ---------------------------------------------------------------------------
 
+
+// ---------------------------------------------------------------------------
+// Workspace integration helper (used by validateConfiguration)
+// ---------------------------------------------------------------------------
+
+function detectWorkspaceIntegration(deps: DoctorDeps): CheckResult {
+  const hasPnpmWorkspace = deps.existsSync('pnpm-workspace.yaml')
+
+  let hasWorkspacesField = false
+  if (!hasPnpmWorkspace && deps.existsSync('package.json')) {
+    try {
+      const raw = deps.readFileSync('package.json', 'utf8') as string
+      const pkg = JSON.parse(raw) as Record<string, unknown>
+      const ws = pkg.workspaces
+      hasWorkspacesField =
+        Array.isArray(ws) || (typeof ws === 'object' && ws !== null && 'packages' in ws)
+    } catch {
+      // package.json parse errors are reported by the version check — skip here
+    }
+  }
+
+  const workspaceSetup = hasPnpmWorkspace || hasWorkspacesField
+  if (!workspaceSetup) {
+    return { name: 'Workspace integration', status: 'PASS', value: 'not a monorepo' }
+  }
+
+  const pluginInstalled = deps.existsSync(
+    'node_modules/@release-it-plugins/workspaces/package.json',
+  )
+  if (pluginInstalled) {
+    return { name: 'Workspace integration', status: 'PASS', value: 'plugin installed' }
+  }
+
+  const source = hasPnpmWorkspace ? 'pnpm-workspace.yaml present' : 'package.json workspaces field'
+  return {
+    name: 'Workspace integration',
+    status: 'WARN',
+    value: `Workspace setup detected (no plugin loaded): ${source}`,
+    detail: [
+      'For multi-package publish + cross-pkg dep sync, run:',
+      '  pnpm add -D @release-it-plugins/workspaces',
+      'Then add `"plugins": {"@release-it-plugins/workspaces": true}` to .release-it.json.',
+      'Skip if you only need per-package CHANGELOG (use GIT_CHANGELOG_PATH).',
+    ].join('\n'),
+  }
+}
+
+
 export function validateConfiguration(deps: DoctorDeps): ConfigurationSection {
   const checks: CheckResult[] = []
   const changelogPath = deps.getEnv('CHANGELOG_FILE') ?? 'CHANGELOG.md'
@@ -426,6 +474,8 @@ export function validateConfiguration(deps: DoctorDeps): ConfigurationSection {
       })
     }
   }
+
+  checks.push(detectWorkspaceIntegration(deps))
 
   return { checks, status: worstStatus(checks.map((c) => c.status)) }
 }

--- a/scripts/doctor.ts
+++ b/scripts/doctor.ts
@@ -303,7 +303,8 @@ function detectWorkspaceIntegration(deps: DoctorDeps): CheckResult {
       const pkg = JSON.parse(raw) as Record<string, unknown>
       const ws = pkg.workspaces
       hasWorkspacesField =
-        Array.isArray(ws) || (typeof ws === 'object' && ws !== null && 'packages' in ws)
+        Array.isArray(ws) ||
+        (typeof ws === 'object' && ws !== null && Array.isArray((ws as { packages?: unknown }).packages))
     } catch {
       // package.json parse errors are reported by the version check — skip here
     }

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -467,6 +467,86 @@ describe('Workspace integration check', () => {
     expect(wsCheck?.status).toBe('PASS')
     expect(wsCheck?.value).toBe('plugin installed')
   })
+
+  it('WARN when package.json has workspaces as object form {packages: [...]}', () => {
+    const pkgWithWorkspacesObject = JSON.stringify({
+      name: 'my-monorepo',
+      version: '1.0.0',
+      workspaces: { packages: ['packages/*'] },
+    })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') return pkgWithWorkspacesObject
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('WARN')
+    expect(wsCheck?.value).toContain('package.json workspaces field')
+  })
+
+  it('PASS when package.json has empty workspaces array (treated as not a monorepo)', () => {
+    // Some scaffolds leave `workspaces: []` from a template; treat as non-monorepo
+    // because there are no actual workspace packages declared.
+    const pkgEmptyArray = JSON.stringify({
+      name: 'maybe-monorepo',
+      version: '1.0.0',
+      workspaces: [],
+    })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') return pkgEmptyArray
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    // Empty array IS still Array.isArray(ws) === true, so detection still WARNs.
+    // This locks the current "file shape, not content" detection rule.
+    expect(wsCheck?.status).toBe('WARN')
+  })
+
+  it('PASS when package.json workspaces is malformed (string, null, etc.)', () => {
+    // A malformed workspaces field (non-array, non-object) should NOT trip detection.
+    const pkgBadWorkspaces = JSON.stringify({
+      name: 'broken-config',
+      version: '1.0.0',
+      workspaces: 'packages/*', // string, not array — invalid per pnpm/yarn/npm spec
+    })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') return pkgBadWorkspaces
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('PASS')
+    expect(wsCheck?.value).toBe('not a monorepo')
+  })
+
+  it('PASS when {packages} is non-array (e.g. null or string) — does not trip detection', () => {
+    const pkgWeirdShape = JSON.stringify({
+      name: 'weird',
+      version: '1.0.0',
+      workspaces: { packages: null },
+    })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') return pkgWeirdShape
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    // Locks the F-003 fix: 'packages' in ws alone was too lenient
+    expect(wsCheck?.status).toBe('PASS')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/doctor.test.ts
+++ b/tests/unit/doctor.test.ts
@@ -408,6 +408,68 @@ describe('validateConfiguration', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Workspace integration (detectWorkspaceIntegration via validateConfiguration)
+// ---------------------------------------------------------------------------
+
+describe('Workspace integration check', () => {
+  it('PASS when no workspace files detected', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn().mockReturnValue(false),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('PASS')
+    expect(wsCheck?.value).toBe('not a monorepo')
+  })
+
+  it('WARN when pnpm-workspace.yaml present and plugin missing', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'pnpm-workspace.yaml'),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('WARN')
+    expect(wsCheck?.value).toContain('pnpm-workspace.yaml present')
+    expect(wsCheck?.detail).toContain('@release-it-plugins/workspaces')
+    expect(wsCheck?.detail).toContain('GIT_CHANGELOG_PATH')
+  })
+
+  it('WARN when package.json workspaces field present and plugin missing', () => {
+    const pkgWithWorkspaces = JSON.stringify({
+      name: 'my-monorepo',
+      version: '1.0.0',
+      workspaces: ['packages/*'],
+    })
+    const deps = makeDeps({
+      existsSync: vi.fn((p: string) => p === 'package.json'),
+      readFileSync: vi.fn((p: string) => {
+        if (p === 'package.json') return pkgWithWorkspaces
+        return ''
+      }),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('WARN')
+    expect(wsCheck?.value).toContain('package.json workspaces field')
+    expect(wsCheck?.detail).toContain('@release-it-plugins/workspaces')
+  })
+
+  it('PASS when workspace files present and plugin is installed', () => {
+    const deps = makeDeps({
+      existsSync: vi.fn(
+        (p: string) =>
+          p === 'pnpm-workspace.yaml' ||
+          p === 'node_modules/@release-it-plugins/workspaces/package.json',
+      ),
+    })
+    const section = validateConfiguration(deps)
+    const wsCheck = section.checks.find(c => c.name === 'Workspace integration')
+    expect(wsCheck?.status).toBe('PASS')
+    expect(wsCheck?.value).toBe('plugin installed')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // summarize
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Prepares the v1.0.0-rc.1 release. Three commits:

1. **`3aadb01` chore: widen release-it peer to support v19 + v20** — drops peer from `^20.0.0` to `^19.0.0 || ^20.0.0`. Tested 19.2.4 against the full preset surface (435 tests, tsc, build, dry-run smoke on default/changelog-only/retry-publish-preflight all green). The v19→v20 delta (undici, proxy-agent, @inquirer/prompts, Node ≥20.19.0) is internal to release-it and doesn't affect our preset. Enables composition with `@release-it-plugins/workspaces` (whose peer maxes at v19 today).

2. **`eadfc77` docs(rc.1): add OSS hygiene + public API surface + ecosystem positioning**
   - `CONTRIBUTING.md` (NEW) — PR conventions, gates, branch prefixes, pre-PR checklist, testing conventions
   - `CODE_OF_CONDUCT.md` (NEW) — Contributor Covenant 2.1
   - `docs/PUBLIC_API.md` (NEW) — explicit stable surface (CLI commands, env vars, config exports, GHA workflow inputs, exit codes) vs internal items + versioning policy
   - `docs/MIGRATION.md` (MODIFY) — v1.0 stability commitments + exit code stability table appended
   - `README.md` (MODIFY) — "Why this preset?", "Ecosystem positioning" table, "Install patterns" (npx/dlx/devDep), "Composing with @release-it-plugins/workspaces" subsection, "Exit codes" reference, badges row updated, Contributing section linked

3. **`6ab5208` feat(doctor): detect workspace setup and recommend plugin**
   - `scripts/doctor.ts` — new `detectWorkspaceIntegration(deps)` check appended to the Configuration section. Detects `pnpm-workspace.yaml` or `package.json` workspaces field. WARN with `pnpm add -D @release-it-plugins/workspaces` recommendation when workspace detected + plugin absent. PASS otherwise.
   - `tests/unit/doctor.test.ts` — 4 new tests covering all 4 detection states (no workspace / yaml only / json field only / workspace + plugin).

## Why minor route then premajor preRelease=rc

The v1.0 path is `v0.13.0` → `v0.14.0` → `v0.15.0` → **`v1.0.0-rc.1`** → 1 week soak → `v1.0.0`. There is **no beta phase**. After this PR merges, we tag with `manual-changelog --increment=premajor --preRelease=rc --ci`. Smart dist-tag in publish.yml picks `rc`, npm `latest` stays at v0.15.0.

## Test plan

- [x] Tests on release-it ^20: 439/439 passing
- [x] Tests on release-it ^19: 435/435 passing (peer compat smoke before adding the doctor tests)
- [x] tsc + build on both
- [x] `node bin/cli.js doctor --json` produces valid JSON with `configuration.checks[]` containing `{name: "Workspace integration", status: "PASS", value: "not a monorepo"}` against this single-package repo
- [ ] CI green (this PR)
- [ ] Manual e2e of hotfix.yml (workflow_dispatch with dry_run=true) and republish.yml (audit-only, no actual run since it moves tags)
- [ ] Post-merge: tag v1.0.0-rc.1, verify smart dist-tag picks `rc`, latest stays 0.15.0

## Closes / Updates

- Updates `#24` v1.0 stability cycle tracking issue (rc.1 phase)

## Out of scope

- Cross-package dep sync — REUSE via `@release-it-plugins/workspaces` per ecosystem analysis (`/tmp/ecosystem-analysis-2026-04-30.md`)
- Canary/snapshot publish — tracked for v1.1 (M effort, builds on existing smart dist-tag)
- Format adapter (Conv. Changelog instead of Keep a Changelog) — gated on demand, IGNORE for v1.0
