### PR TITLE
docs: add llms.txt and AGENTS.md for LLM-era discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent Context — `@oorabona/release-it-preset`
+
+This file is a vendor-neutral pointer for AI coding agents (Claude Code, Cursor, Cline, Aider, Continue, GitHub Copilot Workspace, etc.) working in this repository.
+
+## Mission of this package
+
+A shareable [release-it](https://github.com/release-it/release-it) preset for JavaScript / TypeScript / Node.js packages. Provides:
+
+- 7 release configurations (`default`, `hotfix`, `manual-changelog`, `no-changelog`, `changelog-only`, `republish`, `retry-publish`)
+- 7 utility CLI commands (`init`, `update`, `validate`, `check`, `doctor`, `check-pr`, `retry-publish-preflight`)
+- Reusable GitHub Actions workflows for OIDC trusted publishing
+- [Keep a Changelog](https://keepachangelog.com/) auto-population from Conventional Commits
+- Smart npm dist-tag selection (pre-release identifier extraction, build-metadata strip, version-named fallback for republished older versions)
+
+Audience: solo and small-team JavaScript package maintainers who want OIDC publishing + Keep a Changelog discipline + diagnostic tooling, without the orchestration overhead of changesets/lerna/nx or the full-automation philosophy of semantic-release.
+
+## Where to look first
+
+When asked to add a feature, fix a bug, or modify behavior in this repository:
+
+1. **Read [`CLAUDE.md`](./CLAUDE.md)** — project conventions, architecture quick tour, commit conventions, build/test workflow. Even if you are not Claude Code, the conventions apply.
+2. **Read [`docs/PUBLIC_API.md`](./docs/PUBLIC_API.md)** — the **stable surface** (what semver protects in v1.0+) versus internal items. Modifying anything in the stable list is a major version bump; respect the contract.
+3. **Read [`CONTRIBUTING.md`](./CONTRIBUTING.md)** — Conventional Commits requirement, branch prefixes (`feat/`, `fix/`, `refactor/`, `docs/`, `chore/`), pre-PR checklist (tests + tsc + biome + build), testing conventions (DI pattern, no mocks of `node:fs`/`node:child_process`).
+4. **Browse [`examples/`](./examples/)** — concrete use cases, especially [`examples/monorepo/`](./examples/monorepo/) for the runnable per-package CHANGELOG demo.
+
+## Decisions that shape the codebase
+
+- **Dependency Injection pattern in scripts** — every script in `scripts/` exports a deps-injected function (e.g., `populateChangelog(deps)`) plus a guarded CLI entry. Tests use `vi.fn()` for `execSync`/`readFileSync`/`getEnv`. Do not mock the `node:fs` or `node:child_process` modules themselves; pass plain function literals or `vi.fn()` as the deps. See [`docs/adr/0003-dependency-injection-pattern.md`](./docs/adr/0003-dependency-injection-pattern.md).
+- **No hardcoded values** — every configurable value goes through environment variables with fallbacks defined in `config/constants.js`. See [`docs/PUBLIC_API.md`](./docs/PUBLIC_API.md) for the canonical env var list.
+- **Repository agnostic** — scripts must detect repository URL from git remote, never hardcode.
+- **ESM only** — `"type": "module"` everywhere; no CommonJS in source.
+- **OWASP discipline** — input validation, no command injection, whitelist approach. See `bin/validators.js`.
+- **OIDC trusted publishing** — never reintroduce static `NPM_TOKEN` auth in workflows; the migration is documented in [`docs/MIGRATION.md`](./docs/MIGRATION.md).
+- **Stable error semantics** — exit codes 0/1/2 are frozen for v1.0+; codes 3-9 are reserved. See [`docs/PUBLIC_API.md`](./docs/PUBLIC_API.md#exit-code-stability).
+- **Code comments must reference permanent identifiers** — GH issue refs (`#NN`), ADR file paths, or pure technical descriptions. Session-local labels (review iteration tags, finding IDs, sprint numbers) do not survive the project lifespan and create dangling references.
+
+## Commit conventions (enforced by hook)
+
+Conventional Commits format: `type(scope?)?: lowercase summary`. Types in active use: `feat`, `fix`, `refactor`, `docs`, `chore`, `perf`, `build`, `test`, `ci`. Title ≤ 80 chars. Body wraps ~72 chars. Reference issues with `Closes #N` or `Refs #N` in the body, not the title.
+
+A `commit-msg` hook rejects messages with process artifacts (review iteration tags, finding IDs, severity tags like `BLOCKING`/`CRITICAL`, wave/phase/sprint numbering). Describe results, not the dev journey.
+
+## Environment expectations
+
+- pnpm ≥ 10
+- Node ≥ 20.19.0 (the project's `engines.node` floor; matches release-it v20's minimum)
+- The published preset peer-depends on `release-it ^19.0.0 || ^20.0.0`. Tests + dev install are on v20; v19 was smoke-tested before the constraint was widened.
+
+## When you are stuck
+
+- For project-specific gotchas, search the `docs/` folder first.
+- For agent-specific tooling (Claude Code skills, MCP servers, etc.), check [`CLAUDE.md`](./CLAUDE.md).
+- The [issue tracker](https://github.com/oorabona/release-it-preset/issues) and [Public API doc](./docs/PUBLIC_API.md) are the canonical sources of truth for what's contractual versus internal.
+
+## License
+
+MIT — see [`LICENSE`](./LICENSE).

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,46 @@
+# @oorabona/release-it-preset
+
+> Shareable [release-it](https://github.com/release-it/release-it) preset for JavaScript packages: OIDC trusted publishing, Keep a Changelog discipline, configurable commit-type → CHANGELOG section mapping, a `doctor` CLI for pre-release diagnostic, and recovery presets (`republish`, `retry-publish`) for the scenarios other tools pretend never happen. Targets solo and small-team maintainers who want opinionated CI plumbing without the ceremony of changesets or the full-automation philosophy of semantic-release.
+
+## Documentation
+
+- [README.md](https://github.com/oorabona/release-it-preset/blob/main/README.md): overview, install patterns (npx/pnpm dlx/devDep), 7 release configurations, 7 utility CLI commands, environment variables reference, GitHub Actions workflows, ecosystem positioning vs changesets/semantic-release/release-please/plain release-it
+- [docs/PUBLIC_API.md](https://github.com/oorabona/release-it-preset/blob/main/docs/PUBLIC_API.md): explicit stable v1.0 surface (CLI commands, env vars, config exports, GHA workflow inputs, exit codes 0/1/2 + reserved 3-9) versus internal items, with versioning policy
+- [docs/MIGRATION.md](https://github.com/oorabona/release-it-preset/blob/main/docs/MIGRATION.md): version-by-version upgrade guide with breaking-change details (covers v0.7 → v1.0)
+- [CONTRIBUTING.md](https://github.com/oorabona/release-it-preset/blob/main/CONTRIBUTING.md): PR conventions (Conventional Commits required), branch prefixes, pre-PR checklist, testing conventions
+- [CODE_OF_CONDUCT.md](https://github.com/oorabona/release-it-preset/blob/main/CODE_OF_CONDUCT.md): Contributor Covenant 2.1
+- [SECURITY.md](https://github.com/oorabona/release-it-preset/blob/main/SECURITY.md): vulnerability reporting and supported versions
+- [CLAUDE.md](https://github.com/oorabona/release-it-preset/blob/main/CLAUDE.md): project conventions and architecture for AI agents
+- [AGENTS.md](https://github.com/oorabona/release-it-preset/blob/main/AGENTS.md): vendor-neutral agent context pointer
+
+## Configuration & exports
+
+- [config/default.js](https://github.com/oorabona/release-it-preset/blob/main/config/default.js): standard release flow (changelog auto-population + git + GitHub + npm)
+- [config/hotfix.js](https://github.com/oorabona/release-it-preset/blob/main/config/hotfix.js): emergency patch with auto-generated changelog
+- [config/manual-changelog.js](https://github.com/oorabona/release-it-preset/blob/main/config/manual-changelog.js): release with already-curated `[Unreleased]` content
+- [config/no-changelog.js](https://github.com/oorabona/release-it-preset/blob/main/config/no-changelog.js): release without touching CHANGELOG
+- [config/changelog-only.js](https://github.com/oorabona/release-it-preset/blob/main/config/changelog-only.js): update CHANGELOG only, no version bump
+- [config/republish.js](https://github.com/oorabona/release-it-preset/blob/main/config/republish.js): move existing tag and re-release (dangerous; "I understand the risks" workflow)
+- [config/retry-publish.js](https://github.com/oorabona/release-it-preset/blob/main/config/retry-publish.js): retry failed npm/GitHub publish without git operations
+
+## Examples
+
+- [examples/basic-usage.md](https://github.com/oorabona/release-it-preset/blob/main/examples/basic-usage.md): minimum viable adoption
+- [examples/custom-configuration.md](https://github.com/oorabona/release-it-preset/blob/main/examples/custom-configuration.md): overriding env vars and configs
+- [examples/ci-integration.md](https://github.com/oorabona/release-it-preset/blob/main/examples/ci-integration.md): GitHub Actions integration patterns
+- [examples/reusable-workflows.md](https://github.com/oorabona/release-it-preset/blob/main/examples/reusable-workflows.md): importing the package's reusable workflows in 3 lines of YAML
+- [examples/monorepo-workflow.md](https://github.com/oorabona/release-it-preset/blob/main/examples/monorepo-workflow.md): config composition guide for monorepos
+- [examples/monorepo/](https://github.com/oorabona/release-it-preset/tree/main/examples/monorepo): runnable pnpm workspace demo of `GIT_CHANGELOG_PATH` per-package CHANGELOG generation
+
+## Architecture decisions
+
+- [docs/adr/0001-peer-dependency-on-release-it.md](https://github.com/oorabona/release-it-preset/blob/main/docs/adr/0001-peer-dependency-on-release-it.md): why peer-deps for `release-it`
+- [docs/adr/0002-strict-extends-validation.md](https://github.com/oorabona/release-it-preset/blob/main/docs/adr/0002-strict-extends-validation.md): explicit `extends` enforcement in `.release-it.json`
+- [docs/adr/0003-dependency-injection-pattern.md](https://github.com/oorabona/release-it-preset/blob/main/docs/adr/0003-dependency-injection-pattern.md): DI pattern for testable scripts
+- [docs/adr/0004-conventional-commits-default.md](https://github.com/oorabona/release-it-preset/blob/main/docs/adr/0004-conventional-commits-default.md): why `chore(release): vX.Y.Z` is the default commit message
+
+## Optional
+
+- [BACKLOG_STUDY.md](https://github.com/oorabona/release-it-preset/blob/main/BACKLOG_STUDY.md): post-v1.0 ideas under consideration (plugin system, telemetry opt-in, alt formats)
+- [CHANGELOG.md](https://github.com/oorabona/release-it-preset/blob/main/CHANGELOG.md): release history (Keep a Changelog format)
+- [docs/testing.md](https://github.com/oorabona/release-it-preset/blob/main/docs/testing.md): DI test pattern for the script suite


### PR DESCRIPTION
## Summary

Adds two LLM-era discoverability files:

- **`llms.txt`** — curated project index in the format proposed at [llmstxt.org](https://llmstxt.org). Lets LLM agents (and humans) find the canonical entry points without crawling the whole tree. Lists docs, configs, examples, ADRs, and optional context.
- **`AGENTS.md`** — vendor-neutral agent context (Claude Code, Cursor, Cline, Aider, Continue, Copilot Workspace, etc.). Pointers to `CLAUDE.md` (project conventions), `docs/PUBLIC_API.md` (stable surface), `CONTRIBUTING.md` (dev workflow). Documents the DI pattern, ESM-only constraint, OIDC discipline, the v1.0 contract, and the 'no session-local labels in code comments' rule.

## Why now

Pre-v1.0 stable polish. As tooling agents start recommending release-it presets, having an explicit `llms.txt` and `AGENTS.md` makes the project trivially indexable + tells agents what to read first. Costs nothing to maintain (~150 LOC total, mostly links).

## No version bump

Pure docs addition. No code change. No behavior change.

## Test plan

- [x] llms.txt format conforms to [llmstxt.org spec](https://llmstxt.org) — top-level # heading, blockquote summary, ## sections with link lists, optional ## Optional section
- [x] AGENTS.md cross-references all relevant project docs
- [x] All linked URLs in llms.txt point to actual files in the repo (verified: README, PUBLIC_API, MIGRATION, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, CLAUDE, AGENTS, all 7 configs, 5 examples, 4 ADRs, BACKLOG, CHANGELOG, testing.md)
- [ ] CI green

## Follow-up (not in this PR)

After merge:
- Harmonize GitHub repo description with npm description (cross-platform SEO consistency)
- Disable empty wiki (`gh api ... -X PATCH -f has_wiki=false`) — wiki was never initialized