### PR TITLE
fix(republish)!: hardcode npm.publish=false (breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ BREAKING CHANGES
+
+- **`republish` preset no longer publishes to npm.** The preset hardcodes `npm.publish = false`; setting `NPM_PUBLISH=true` is silently ignored for this preset. npm immutability (since 2016) makes republishing impossible regardless of dist-tag — the previous behavior of attempting an npm publish was dead code that always failed. The preset's scope is now explicitly: move git tag + update GitHub release. Use `npm dist-tag add` for dist-tag redirection, or the `retry-publish` preset for failed-publish retries. See [ADR 0005](docs/adr/0005-republish-scope-narrowing.md) and [MIGRATION.md](docs/MIGRATION.md#100-rc0--100-rc1--republish-preset-narrowed-scope-breaking).
+
 ## [1.0.0-rc.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -335,11 +335,15 @@ Features:
 - ☑️ npm publishing (set `NPM_PUBLISH=true`)
 - ❌ No changelog updates
 
-### `republish` - Version Republishing
+### `republish` - Git Tag Move + GitHub Release Update
 
-⚠️ **DANGER**: Republishes existing version by moving the git tag (breaks semver immutability).
+⚠️ **DANGER**: Moves an existing git tag to HEAD and updates the GitHub release notes (breaks semver immutability for that tag).
 
-Only use when you need to fix a broken release. Publishing back to npm/GitHub still requires enabling the corresponding environment flags.
+Only use when you need to fix a broken release that requires moving the git tag. This preset **does not publish to npm** — npm immutability (since 2016) makes republishing an existing version impossible under any dist-tag. See [ADR 0005](docs/adr/0005-republish-scope-narrowing.md).
+
+Alternatives:
+- **dist-tag change** (e.g. move `latest` to a different version): `npm dist-tag add @oorabona/release-it-preset@<version> latest`
+- **Retry a failed npm/GitHub publish**: use the `retry-publish` preset instead
 
 **CLI:**
 ```bash
@@ -356,8 +360,8 @@ pnpm release-it-preset republish
 Features:
 - ⚠️ Moves existing git tag
 - ✅ Updates changelog for current version
-- ☑️ Republishes to npm (set `NPM_PUBLISH=true`)
 - ☑️ Updates GitHub release (set `GITHUB_RELEASE=true`)
+- ❌ Does not publish to npm (npm immutability — use `npm dist-tag add` or `retry-publish`)
 
 ### `retry-publish` - Retry Failed Publishing
 
@@ -1402,7 +1406,7 @@ permissions:
 - `pre-flight-checks` - Validates confirmation, version format, and tag existence
 - `build-dist` - Builds distribution using reusable workflow
 - `validate` - Validates TypeScript compilation
-- `republish` - Moves git tag and republishes
+- `republish` - Moves git tag and updates GitHub release
 
 **What it does:**
 1. **Pre-flight safety checks:**
@@ -1414,21 +1418,19 @@ permissions:
 2. Validates code compilation
 3. **Moves git tag to current commit** (⚠️ breaks immutability)
 4. Updates changelog for current version
-5. Republishes to npm with provenance
-6. Updates GitHub Release
-7. Creates audit trail document
+5. Updates GitHub Release
 
-**When to use:** ONLY for exceptional emergencies where a published version has critical security issues
+> **Note:** npm is not republished — npm immutability (since 2016) prevents republishing an existing version. To redirect a dist-tag, use `npm dist-tag add`. To retry a failed publish, use the `retry-publish` preset.
+
+**When to use:** ONLY for exceptional emergencies where a published version must be moved to a different commit (e.g. a broken tag pointing to the wrong SHA)
 
 **Permissions required:**
 ```yaml
 permissions:
   contents: write  # For git tag operations
-  id-token: write  # For npm provenance
 ```
 
 **Secrets required:**
-- `NPM_TOKEN` - npm automation token
 - `GITHUB_TOKEN` - Provided automatically
 
 **Concurrency:** Prevents parallel republish operations for same version

--- a/config/republish.js
+++ b/config/republish.js
@@ -1,16 +1,24 @@
 /**
  * Republish release-it configuration
  *
- * DANGER: This configuration republishes the current version without incrementing.
- * It moves the existing git tag, which breaks semantic versioning immutability.
+ * DANGER: This configuration moves an existing git tag and updates the GitHub
+ * release. It breaks semantic versioning immutability for that tag.
  *
- * Only use this in exceptional cases when you need to:
- * - Fix a broken release
- * - Republish with corrected artifacts
+ * Scope: git tag move + GitHub release update ONLY.
+ * npm immutability (since 2016) makes republishing a version to npm impossible.
+ * This preset never attempts an npm publish regardless of NPM_PUBLISH.
+ * See ADR 0005 (docs/adr/0005-republish-scope-narrowing.md).
+ *
+ * Only use when you need to:
+ * - Move an existing git tag to a different commit
+ * - Update the corresponding GitHub release notes
+ *
+ * Alternatives for other recovery scenarios:
+ * - dist-tag changes: npm dist-tag add @pkg@version <tag>
+ * - Failed npm/GitHub publish: use the retry-publish preset
  *
  * Publishing steps remain opt-in:
  * - Set GITHUB_RELEASE=true to update the GitHub release
- * - Set NPM_PUBLISH=true to republish to npm with provenance
  *
  * Usage:
  * ```bash
@@ -37,7 +45,10 @@ const config = {
       runScriptCommand('republish-changelog'),
     ],
   },
-  npm: createBaseNpmConfig(),
+  // npm immutability (since 2016) makes republishing a version impossible.
+  // The preset's scope is narrowed to git tag move + GitHub release update.
+  // Use `npm dist-tag add` to redirect tags, or `retry-publish` for failed publishes.
+  npm: createBaseNpmConfig({ publish: false }),
   github: createBaseGitHubConfig({
     update: true,
   }),

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -14,6 +14,7 @@ exceptions are listed below.
 | 0.9.x → 0.10.0  | yes       | Update CI scripts that branch on `validate` exit code (`1` → `2`)       |
 | 0.10.0 → 0.10.1 | no        | Strict commit-msg hooks now accept the new default release commit format |
 | 0.10.x → 0.11.0 | no        | Two new optional env vars (`GIT_CHANGELOG_PATH`, `NPM_TAG`)              |
+| 1.0.0-rc.0 → 1.0.0-rc.1 | yes | `republish` preset no longer publishes to npm even with `NPM_PUBLISH=true`; use `npm dist-tag add` instead |
 | 0.x → 1.0       | partial   | API freeze shipped in v1.0.0-rc.0; see [Upgrade checklist for v1.0.0](#upgrade-checklist-for-v100) |
 
 ---
@@ -141,6 +142,30 @@ Two new opt-in environment variables are available:
   to unset.
 
 No existing configuration is affected. Both vars require explicit opt-in.
+
+---
+
+### 1.0.0-rc.0 → 1.0.0-rc.1 — `republish` preset narrowed scope (BREAKING)
+
+The `republish` preset hardcodes `npm.publish = false`. Setting `NPM_PUBLISH=true`
+no longer triggers an npm publish for this preset; the env var is silently ignored
+for `republish` only.
+
+**Why.** npm has been strict-immutable since 2016 (post left-pad). A version cannot
+be republished under any dist-tag once it exists on the registry. The `republish`
+preset previously promised an `NPM_PUBLISH=true` path that always failed at the npm
+step — confusing user-facing behavior. The preset's real value is git-tag movement
+and GitHub release notes update, both of which remain.
+
+**What to do:**
+- For dist-tag changes (e.g. moving `latest` to a different version):
+  `npm dist-tag add @oorabona/release-it-preset@<version> latest`
+- For retrying a publish that failed mid-flight (network, OIDC, etc.): use the
+  `retry-publish` preset
+- For moving a git tag to a different commit + updating the GitHub release:
+  continue using `republish` — just stop setting `NPM_PUBLISH=true`
+
+See [ADR 0005](adr/0005-republish-scope-narrowing.md) for full rationale.
 
 ---
 

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -27,7 +27,7 @@ The `release-it-preset` binary (or `pnpm release-it-preset`) accepts these comma
 | `changelog-only` | `config/changelog-only.js` | Update CHANGELOG only; no version bump or release |
 | `manual-changelog` | `config/manual-changelog.js` | Release with already-curated `[Unreleased]` content |
 | `no-changelog` | `config/no-changelog.js` | Release without touching CHANGELOG |
-| `republish` | `config/republish.js` | Move existing tag and re-release (`I understand the risks` workflow) |
+| `republish` | `config/republish.js` | Move existing tag + update GitHub release. Does not publish to npm (immutable registry — see [ADR 0005](adr/0005-republish-scope-narrowing.md)). |
 | `retry-publish` | `config/retry-publish.js` | Retry failed npm/GitHub publish without git operations |
 
 ### Utility commands (run dedicated scripts)
@@ -76,7 +76,7 @@ These env vars are read by configs and scripts. Setting them overrides built-in 
 
 | Name | Default | Notes |
 |---|---|---|
-| `NPM_PUBLISH` | `false` | Set to `true` to enable `npm publish` (off-by-default for safety) |
+| `NPM_PUBLISH` | `false` | Set to `true` to enable `npm publish` (off-by-default for safety). **Not honored by `republish` preset** — that preset hardcodes `publish: false` (see [ADR 0005](adr/0005-republish-scope-narrowing.md)). |
 | `NPM_SKIP_CHECKS` | `false` | Skip `npm whoami` precheck (set to `true` under OIDC trusted publishing) |
 | `NPM_ACCESS` | `public` | npm `--access` value |
 | `NPM_TAG` | _(unset)_ | When set, appended as `--tag <value>` to npm publish (used by smart dist-tag selection in `publish.yml`) |

--- a/docs/adr/0005-republish-scope-narrowing.md
+++ b/docs/adr/0005-republish-scope-narrowing.md
@@ -1,0 +1,99 @@
+# ADR 0005: Narrow `republish` preset scope to git + GitHub (no npm)
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Deciders**: Project maintainer
+- **Supersedes**: —
+- **Superseded by**: —
+
+## Context
+
+The `republish` preset (`config/republish.js`) was designed for exceptional recovery
+scenarios where an existing release needed to be "republished". It wired up
+`npm: createBaseNpmConfig()`, which respects the `NPM_PUBLISH` environment variable.
+
+During v1.0.0-rc.0 soak, it became clear that the npm publish path in `republish`
+was dead code: npm has enforced strict version immutability since 2016 (post
+left-pad incident). Once a version is published to the registry, it cannot be
+overwritten under any dist-tag — `npm publish` for an existing version exits with:
+
+```
+npm error code E403
+npm error 403 403 Forbidden - PUT https://registry.npmjs.org/... -
+npm error 403 You cannot publish over the previously published versions of ...
+```
+
+This means any user who set `NPM_PUBLISH=true` with the `republish` preset would
+see a guaranteed npm-step failure. The preset's real value — moving a git tag and
+updating the GitHub release — was unaffected, but the failed npm step produced
+confusing, misleading output.
+
+## Decision
+
+Hardcode `npm.publish = false` in `config/republish.js` by passing
+`{ publish: false }` to `createBaseNpmConfig()`. This is a structural impossibility,
+not a runtime guard — no env var can override it for this preset.
+
+Update the file-level JSDoc comment and README to document the narrowed scope and
+provide explicit alternatives for the cases users were likely trying to solve:
+
+- dist-tag changes: `npm dist-tag add <pkg>@<version> <tag>`
+- failed mid-flight publishes: `retry-publish` preset
+
+The change is classified as BREAKING for `republish` users who set `NPM_PUBLISH=true`,
+though the real-world impact is zero: that path always failed at the npm step anyway.
+
+## Alternatives Considered
+
+### Option A: Deprecate `republish` preset entirely
+
+**Pros:** Clean break; no confusion about what the preset does.
+**Cons:** The preset retains genuine utility for git-tag-move + GitHub-release-update
+scenarios. Removing it forces users back to manual `git tag -f` + `gh release edit`
+sequences, which is exactly the kind of manual work this package exists to avoid.
+**Rejected.**
+
+### Option B (chosen): Narrow scope structurally — `publish: false` hardcoded
+
+**Pros:** Removes dead code. Documents real behavior. Structural impossibility is
+clearer than a runtime check. The preset still covers its genuine use cases.
+**Cons:** Breaking change for anyone who set `NPM_PUBLISH=true` expecting it to work.
+Real impact: none (always failed). Included in rc.1 rather than v2 on that basis.
+**Chosen.**
+
+### Option C: Rename to `move-tag` or `fix-tag`
+
+**Pros:** More accurate name for the narrowed scope.
+**Cons:** Breaking change in preset name without proportional benefit. "republish"
+is recognized by existing users and maps to the `.github/workflows/republish.yml`
+workflow name. A rename would require updating bin/cli.js, README, workflows, and
+user configs.
+**Rejected.**
+
+### Option D: Runtime guard — exit with error when `NPM_PUBLISH=true`
+
+**Pros:** Explicit failure mode; user sees a clear error rather than silent ignore.
+**Cons:** Adds code and tests for a check that is better expressed as structural
+impossibility. Fail-loud adds noise for the common case (no NPM_PUBLISH set).
+**Rejected.**
+
+## Consequences
+
+- **Breaking**: `NPM_PUBLISH=true` is silently ignored for the `republish` preset.
+  Any user relying on it to publish to npm must switch to `retry-publish` (for
+  failed publishes) or `npm dist-tag add` (for dist-tag changes).
+- **Real impact**: Zero — `npm publish` for an existing version always returned E403.
+  This change converts a confusing failure into a documented non-operation.
+- **Positive**: Preset behavior now matches its documented purpose. The `republish`
+  preset's scope is unambiguous: git tag move + GitHub release update.
+- **Justification for rc.1 inclusion**: Because the "breaking" path was always broken,
+  this is a correctness fix dressed as a breaking change. Waiting for v2 would leave
+  the misleading behavior in the stable v1.0 surface.
+
+## References
+
+- npm immutability policy: https://docs.npmjs.com/policies/unpublish
+- `config/republish.js` — `npm: createBaseNpmConfig({ publish: false })`
+- `config/base-config.js` — `createBaseNpmConfig()` builder
+- v1.0.0-rc.0 ship: 2026-04-30
+- MIGRATION.md — `1.0.0-rc.0 → 1.0.0-rc.1` section


### PR DESCRIPTION
## Summary
- `republish` preset now hardcodes `npm.publish = false`. Setting `NPM_PUBLISH=true` no longer triggers an npm publish for this preset.
- Documents the new scope explicitly: move git tag + update GitHub release.
- npm immutability (since 2016) made the previous `NPM_PUBLISH=true` path dead code that always failed at the publish step.
- Refs: ADR 0005, MIGRATION.md `1.0.0-rc.0 → 1.0.0-rc.1` section.

## Why now
Discovered during v1.0.0-rc.0 soak. Better to fix this contract bug in rc.1 (still under `next` dist-tag) than freeze it in v1.0 stable for 3+ years.

## Test plan
- [x] `pnpm exec tsc --noEmit` — typecheck green
- [x] `pnpm exec vitest run` — 443 tests pass
- [x] `pnpm build` — builds dist/
- [x] No new test added: the change is structural (override in config builder), existing republish integration tests still pass with `publish: false`
