### PR TITLE
feat(cli): warn instead of error on extends/preset mismatch + dogfood init

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@oorabona/release-it-preset/config/default"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CLI no longer errors on `.release-it.json` extends/preset mismatch.** When the user has `.release-it.json` extending one preset (e.g. `default`) and invokes a different preset (e.g. `retry-publish`), the CLI now uses the invoked preset's config directly (via `--config`) and prints a warning instead of failing. The user's `.release-it.json` customizations are skipped for that run. Use the matching preset name to keep customizations.
 - **Generated workflow template simplified**: `init --with-workflows` now emits `pnpm exec release-it-preset retry-publish --ci` instead of the previous `release-it --ci --config $(node -e require.resolve(...))` workaround.
+- **Tooling that depended on the previous exit-1 mismatch error must adapt**: wrappers checking for exit code 1 to gate on misconfigured extends should now parse the new `⚠️ Note: your .release-it.json extends ...` warning prefix on stderr, or pre-check the `extends` field manually. The hard `extends`-required check still exits 1 (unchanged).
 
 ## [1.1.0] - 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`init` monorepo auto-detection**: detects `pnpm-workspace.yaml` (block-list form) or `package.json#workspaces` and scaffolds per-package `.release-it.json`; root config is skipped to avoid conflicts.
 - **`init` adds `release:patch`, `release:minor`, `release:major` scripts** to the standard set so users can type `pnpm release:minor` directly (the existing `pnpm release minor` passthrough still works too).
 
+### Changed
+
+- **CLI no longer errors on `.release-it.json` extends/preset mismatch.** When the user has `.release-it.json` extending one preset (e.g. `default`) and invokes a different preset (e.g. `retry-publish`), the CLI now uses the invoked preset's config directly (via `--config`) and prints a warning instead of failing. The user's `.release-it.json` customizations are skipped for that run. Use the matching preset name to keep customizations.
+- **Generated workflow template simplified**: `init --with-workflows` now emits `pnpm exec release-it-preset retry-publish --ci` instead of the previous `release-it --ci --config $(node -e require.resolve(...))` workaround.
+
 ## [1.1.0] - 2026-05-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -957,7 +957,7 @@ pnpm release-it-preset default
 
 **Why `extends` is required:** Without it, release-it only loads your config file and uses release-it's own defaults. The preset is never loaded, so you lose important defaults like `npm.publish: false`.
 
-#### Error 2: Preset mismatch
+#### Note: Preset mismatch (warning, not error)
 
 ```bash
 # .release-it.json extends "default":
@@ -968,14 +968,13 @@ pnpm release-it-preset default
 # But you run:
 pnpm release-it-preset hotfix
 
-# ❌ Configuration mismatch error!
-#    CLI preset:               hotfix
-#    .release-it.json extends: default
-#
-#    Either:
-#      1. Run: release-it-preset default
-#      2. Update .release-it.json extends to: "@oorabona/release-it-preset/config/hotfix"
+# ⚠️  Note: your .release-it.json extends "default"
+#    but you invoked the "hotfix" preset.
+#    Using "hotfix" config directly; .release-it.json customizations are ignored for this run.
+#    To use your customizations, run: release-it-preset default
 ```
+
+> **Note**: invoking a preset different from your `.release-it.json` extends value now warns and uses the invoked preset's config (was: hard error). Use the matching name to keep your customizations.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -902,7 +902,7 @@ pnpm release-it-preset default
 - The `extends` field loads the preset
 - release-it merges your overrides on top via c12
 - **Your values take precedence** over preset defaults
-- CLI validates that `extends` matches the command
+- CLI validates that `extends` is present; mismatched preset name warns and uses the invoked preset's config for that run
 
 **Pros:**
 - ✅ **Recommended for customization**

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -160,21 +160,19 @@ function handleReleaseCommand(configName, args) {
       const extendsPreset = extendsMatch?.[1];
 
       if (extendsPreset && extendsPreset !== configName) {
-        console.error(`\n❌ Configuration mismatch error!`);
-        console.error(`   CLI preset:               ${configName}`);
-        console.error(`   .release-it.json extends: ${extendsPreset}`);
-        console.error(``);
-        console.error(`Either:`);
-        console.error(`  1. Run: release-it-preset ${extendsPreset}`);
-        console.error(`     → Use the preset specified in your config file`);
-        console.error(``);
-        console.error(`  2. Update .release-it.json extends to: "${expectedExtends}"`);
-        console.error(`     → Match your config file to the CLI command\n`);
-        process.exit(1);
+        console.warn(`⚠️  Note: your .release-it.json extends "${extendsPreset}"`);
+        console.warn(`   but you invoked the "${configName}" preset.`);
+        console.warn(`   Using "${configName}" config directly; .release-it.json customizations are ignored for this run.`);
+        console.warn(`   To use your customizations, run: release-it-preset ${extendsPreset}`);
+        console.warn(``);
+        // Force --config flag to use OUR preset, ignore user's .release-it.json
+        fullArgs = ['--config', configPath, ...args];
+      } else {
+        console.log(`✅ Config validated: preset "${configName}"`);
+        console.log(`📝 Using: ${userConfigPath}\n`);
+        // Let release-it discover .release-it.json and merge via extends
+        fullArgs = [...args];
       }
-
-      console.log(`✅ Config validated: preset "${configName}"`);
-      console.log(`📝 Using: ${userConfigPath}\n`);
     } catch (error) {
       if (error instanceof SyntaxError) {
         console.error(`❌ Failed to parse .release-it.json: ${error.message}`);
@@ -183,9 +181,6 @@ function handleReleaseCommand(configName, args) {
       }
       process.exit(1);
     }
-
-    // Let release-it discover .release-it.json and merge via extends
-    fullArgs = [...args];
   } else {
     // No user config - use preset directly
     console.log(`📝 Using preset config directly: ${configPath}`);

--- a/docs/adr/0002-strict-extends-validation.md
+++ b/docs/adr/0002-strict-extends-validation.md
@@ -1,6 +1,6 @@
 # ADR-0002: Strict `extends` validation in `.release-it.json`
 
-- **Status**: Accepted
+- **Status**: Amended (2026-05-07) — see [ADR-0006](./0006-relaxed-mismatch-policy.md) for the relaxed mismatch policy. The first invariant ("extends required") remains in force.
 - **Date**: 2025-10-06
 - **Deciders**: maintainers
 

--- a/docs/adr/0002-strict-extends-validation.md
+++ b/docs/adr/0002-strict-extends-validation.md
@@ -37,6 +37,14 @@ Without an explicit `extends`, the tool has no way to discover the preset.
 
 ## Decision
 
+> **Note (2026-05-07)**: The "hard-error on mismatch" invariant below has been
+> superseded by [ADR-0006](./0006-relaxed-mismatch-policy.md). The CLI now warns
+> and uses the invoked preset's config via `--config <path>` for that run.
+> The first invariant in this ADR — `extends` is required when `.release-it.json`
+> exists — REMAINS in force.
+
+(Original decision text below preserved for historical context.)
+
 When `.release-it.json` exists in the working directory, `bin/cli.js` validates
 that it contains an `extends` field pointing to the invoked preset. Specifically:
 

--- a/docs/adr/0006-relaxed-mismatch-policy.md
+++ b/docs/adr/0006-relaxed-mismatch-policy.md
@@ -1,0 +1,36 @@
+# ADR-0006: Relaxed extends/preset mismatch policy
+
+## Status
+
+Accepted (2026-05-07). Supersedes the second invariant of [ADR-0002](./0002-strict-extends-validation.md) ("hard-error on mismatch"). Retains ADR-0002's first invariant (`extends` is required).
+
+## Context
+
+ADR-0002 codified hard-erroring on extends/preset mismatch (e.g. `.release-it.json` extends `default`, user invokes `release-it-preset retry-publish`). In practice this proved too strict:
+
+- Operational presets (`retry-publish`, `republish`) and alternate-flow presets (`no-changelog`, `manual-changelog`) are most useful **on top of** an existing extended config; forcing the user to maintain a matching `.release-it.json` per preset is friction.
+- Our own generated `init --with-workflows` template was driven into a `release-it --config $(node -e require.resolve(...))` workaround pattern just to bypass the CLI — a clear smell that the CLI's contract was over-constrained.
+- The original decision lacked an escape hatch: even an explicit `--config <path>` couldn't override the assertion.
+
+## Decision
+
+When `.release-it.json` extends preset X and the user invokes preset Y (Y ≠ X):
+
+1. Print a warning naming both presets and the recovery command (`release-it-preset <X>`).
+2. Pass `--config <Y-path>` to release-it so the invoked preset's config wins; the user's `.release-it.json` customizations are skipped for that run.
+3. Continue execution (no exit-1).
+
+The `extends`-required check (ADR-0002 first invariant) remains in place: a `.release-it.json` without `extends` still hard-errors, because the user clearly intended preset semantics but didn't wire them up.
+
+## Consequences
+
+- **Pro**: operational and alternate-flow presets are usable from any extended config without editing `.release-it.json`. Generated workflow template simplifies to `pnpm exec release-it-preset retry-publish --ci`.
+- **Pro**: the warning surfaces the override transparently — users see exactly when their customizations are ignored and how to keep them.
+- **Con (mitigated)**: tooling that relied on exit-1 mismatch as a signal must now parse the warning prefix or pre-check `extends`. Captured in CHANGELOG `### Changed`.
+- **Reverses** the ADR-0002 second invariant. Does not affect any other decision.
+
+## Alternatives considered
+
+- Whitelist of "operational" presets (retry-publish/republish/hotfix) bypassing the check: rejected because the operational/shape distinction is artificial — `no-changelog` and `manual-changelog` are also legitimate "I want to do this run differently" cases.
+- Keep the strict check, push the workaround pattern into the template forever: rejected because the workaround is a smell pointing back at the CLI being over-constrained.
+- Drop the `extends`-required check too: rejected because the missing-extends footgun (user creates an empty `.release-it.json` thinking they're overriding when they're actually getting release-it defaults) is the load-bearing safety net. Mismatch was not.

--- a/examples/custom-configuration.md
+++ b/examples/custom-configuration.md
@@ -45,7 +45,7 @@ pnpm release-it-preset default
 - The `extends` field loads the preset configuration
 - release-it merges your overrides on top via c12
 - **Your values take precedence** over preset defaults
-- CLI validates that `extends` matches the command
+- CLI validates that `extends` is present; mismatched preset name warns and uses the invoked preset's config for that run
 
 **Benefits:**
 - ✅ Explicit preset declaration

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "release:minor": "node ./bin/cli.js default minor",
     "release:major": "node ./bin/cli.js default major",
     "release:dry": "node ./bin/cli.js default --dry-run",
-    "changelog:update": "release-it-preset update"
+    "changelog:update": "node ./bin/cli.js update"
   },
   "peerDependencies": {
     "release-it": "^19.0.0 || ^20.0.0"

--- a/package.json
+++ b/package.json
@@ -62,13 +62,13 @@
     "release": "pnpm run release:default",
     "release:default": "node ./bin/cli.js default",
     "release:default:dry-run": "node ./bin/cli.js default --dry-run",
-    "release:no-changelog": "node ./bin/cli.js no-changelog",
-    "release:changelog-only": "node ./bin/cli.js changelog-only",
-    "release:manual-changelog": "node ./bin/cli.js manual-changelog",
+    "release:dev:no-changelog": "node ./bin/cli.js no-changelog",
+    "release:dev:changelog-only": "node ./bin/cli.js changelog-only",
+    "release:dev:manual-changelog": "node ./bin/cli.js manual-changelog",
     "release:hotfix": "node ./bin/cli.js hotfix",
-    "release:republish": "node ./bin/cli.js republish",
-    "release:retry-preflight": "node ./bin/cli.js retry-publish-preflight",
-    "release:retry-publish": "node ./bin/cli.js retry-publish",
+    "release:dev:republish": "node ./bin/cli.js republish",
+    "release:dev:retry-preflight": "node ./bin/cli.js retry-publish-preflight",
+    "release:dev:retry-publish": "node ./bin/cli.js retry-publish",
     "release:update": "node ./bin/cli.js update",
     "release:validate": "node ./bin/cli.js validate",
     "release:validate:allow-dirty": "node ./bin/cli.js validate --allow-dirty",
@@ -85,7 +85,12 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:ui": "vitest --ui",
-    "prepublishOnly": "pnpm build && echo 'Running prepublish checks...' && test -f README.md && test -f LICENSE"
+    "prepublishOnly": "pnpm build && echo 'Running prepublish checks...' && test -f README.md && test -f LICENSE",
+    "release:patch": "node ./bin/cli.js default patch",
+    "release:minor": "node ./bin/cli.js default minor",
+    "release:major": "node ./bin/cli.js default major",
+    "release:dry": "node ./bin/cli.js default --dry-run",
+    "changelog:update": "release-it-preset update"
   },
   "peerDependencies": {
     "release-it": "^19.0.0 || ^20.0.0"

--- a/scripts/templates/workflows/release.yml.template
+++ b/scripts/templates/workflows/release.yml.template
@@ -60,6 +60,4 @@ jobs:
           GITHUB_RELEASE: 'true'
           NPM_SKIP_CHECKS: 'true'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          CONFIG_PATH=$(node -e "console.log(require.resolve('@oorabona/release-it-preset/config/retry-publish'))")
-          pnpm exec release-it --ci --config "$CONFIG_PATH"
+        run: pnpm exec release-it-preset retry-publish --ci

--- a/tests/integration/cli-modes.test.ts
+++ b/tests/integration/cli-modes.test.ts
@@ -367,7 +367,7 @@ describe('CLI Modes - Config Validation and Security', () => {
     expect(result.stderr).toContain('missing the required "extends" field')
   })
 
-  it('should validate extends matches CLI preset command', async () => {
+  it('warns on mismatch and uses preset config directly', async () => {
     createTestEnv({
       '.release-it.json': JSON.stringify({
         extends: '@oorabona/release-it-preset/config/hotfix',
@@ -377,8 +377,32 @@ describe('CLI Modes - Config Validation and Security', () => {
 
     const result = await execCLI(['default']) // Mismatch: CLI says default, config says hotfix
 
-    expect(result.code).toBe(1)
-    expect(result.stderr).toContain('Configuration mismatch')
+    // CLI no longer hard-errors on mismatch — warns and uses the invoked preset directly.
+    // Exit code may still be non-zero if release-it itself fails on git/npm preconditions
+    // (no git repo, no tag, etc.), but the old "Configuration mismatch error!" must be gone.
+    expect(result.stderr).toContain('Note: your .release-it.json extends "hotfix"')
+    expect(result.stderr).toContain('but you invoked the "default" preset')
+    expect(result.stderr).toContain('.release-it.json customizations are ignored for this run')
+    expect(result.stderr).not.toContain('Configuration mismatch error!')
+  })
+
+  it('user with .release-it.json extends default invokes retry-publish — no error, warning printed, retry-publish.js used', async () => {
+    createTestEnv({
+      '.release-it.json': JSON.stringify({
+        extends: '@oorabona/release-it-preset/config/default',
+      }),
+      'package.json': JSON.stringify({ name: 'test', version: '1.0.0' }),
+    })
+
+    const result = await execCLI(['retry-publish', '--dry-run'])
+
+    // Should warn and override to retry-publish.js, not exit 1 on mismatch
+    expect(result.stderr).toContain('Note: your .release-it.json extends "default"')
+    expect(result.stderr).toContain('but you invoked the "retry-publish" preset')
+    expect(result.stderr).toContain('customizations are ignored for this run')
+    // Exit code may be non-zero from release-it itself (git/npm preconditions) but not from CLI mismatch check
+    // The key assertion: no "Configuration mismatch error!" in output
+    expect(result.stderr).not.toContain('Configuration mismatch error!')
   })
 })
 

--- a/tests/integration/cli-modes.test.ts
+++ b/tests/integration/cli-modes.test.ts
@@ -104,6 +104,22 @@ function execCLIWithArgCapture(
 
     let stdout = ''
     let stderr = ''
+    let settled = false
+    // Declared before `settle` to avoid TDZ: if spawn errors immediately (before
+    // setTimeout runs), the error event fires synchronously and settle() would
+    // reference timeoutHandle while it is still in the temporal dead zone.
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined
+
+    const settle = (result: { code: number | null; stdout: string; stderr: string }) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle)
+      }
+      resolve(result)
+    }
 
     child.stdout?.on('data', data => {
       stdout += data.toString()
@@ -113,19 +129,14 @@ function execCLIWithArgCapture(
       stderr += data.toString()
     })
 
-    child.on('close', code => {
-      resolve({ code, stdout, stderr })
-    })
+    child.on('close', code => settle({ code, stdout, stderr }))
+    child.on('error', error => settle({ code: 1, stdout, stderr: error.message }))
 
-    child.on('error', error => {
-      resolve({ code: 1, stdout, stderr: error.message })
-    })
-
-    // Timeout after 5 seconds to prevent hanging
-    setTimeout(() => {
+    // Timeout after 10 seconds to prevent hanging
+    timeoutHandle = setTimeout(() => {
       child.kill()
-      resolve({ code: 1, stdout, stderr: 'Test timeout after 5s' })
-    }, 5000)
+      settle({ code: 1, stdout, stderr: 'Test timeout after 10s' })
+    }, 10_000)
   })
 }
 

--- a/tests/integration/cli-modes.test.ts
+++ b/tests/integration/cli-modes.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -63,6 +63,72 @@ function execCLI(
     }, 5000)
   })
 }
+
+
+/**
+ * Helper to execute CLI with a mock `release-it` binary injected into PATH.
+ * The mock prints all received arguments to stderr as "MOCK_ARGS: <json>".
+ * This lets tests assert that `--config <preset-path>` is forwarded to
+ * release-it without having to read cli.js internals.
+ */
+function execCLIWithArgCapture(
+  args: string[],
+  cwd: string = TEST_DIR,
+): Promise<{
+  code: number | null
+  stdout: string
+  stderr: string
+}> {
+  // Create a local bin/ directory with a fake `release-it` that echoes its args
+  const mockBinDir = join(cwd, '.mock-bin')
+  if (!existsSync(mockBinDir)) {
+    mkdirSync(mockBinDir, { recursive: true })
+  }
+  const mockReleaseIt = join(mockBinDir, 'release-it')
+  writeFileSync(
+    mockReleaseIt,
+    '#!/usr/bin/env node\nprocess.stderr.write("MOCK_ARGS: " + JSON.stringify(process.argv.slice(2)) + "\\n");\nprocess.exit(0);\n',
+    'utf8',
+  )
+  chmodSync(mockReleaseIt, 0o755)
+
+  return new Promise(resolve => {
+    const child = spawn('node', [CLI_PATH, ...args], {
+      cwd,
+      env: {
+        ...process.env,
+        NO_COLOR: '1',
+        PATH: `${mockBinDir}:${process.env.PATH}`, // Intercept release-it lookup
+      },
+    })
+
+    let stdout = ''
+    let stderr = ''
+
+    child.stdout?.on('data', data => {
+      stdout += data.toString()
+    })
+
+    child.stderr?.on('data', data => {
+      stderr += data.toString()
+    })
+
+    child.on('close', code => {
+      resolve({ code, stdout, stderr })
+    })
+
+    child.on('error', error => {
+      resolve({ code: 1, stdout, stderr: error.message })
+    })
+
+    // Timeout after 5 seconds to prevent hanging
+    setTimeout(() => {
+      child.kill()
+      resolve({ code: 1, stdout, stderr: 'Test timeout after 5s' })
+    }, 5000)
+  })
+}
+
 
 /**
  * Helper to create a test directory structure
@@ -394,15 +460,29 @@ describe('CLI Modes - Config Validation and Security', () => {
       'package.json': JSON.stringify({ name: 'test', version: '1.0.0' }),
     })
 
-    const result = await execCLI(['retry-publish', '--dry-run'])
+    // Use the arg-capturing variant so we can verify --config is forwarded.
+    // A regression that drops ['--config', configPath] from cli.js:169 would
+    // silently fall back to .release-it.json's "extends: default" — the mock
+    // shows exactly what release-it receives and fails this assertion.
+    const result = await execCLIWithArgCapture(['retry-publish', '--dry-run'])
 
     // Should warn and override to retry-publish.js, not exit 1 on mismatch
     expect(result.stderr).toContain('Note: your .release-it.json extends "default"')
     expect(result.stderr).toContain('but you invoked the "retry-publish" preset')
     expect(result.stderr).toContain('customizations are ignored for this run')
-    // Exit code may be non-zero from release-it itself (git/npm preconditions) but not from CLI mismatch check
     // The key assertion: no "Configuration mismatch error!" in output
     expect(result.stderr).not.toContain('Configuration mismatch error!')
+
+    // Verify --config <retry-publish.js> was actually forwarded to release-it.
+    // If this line is missing from cli.js, MOCK_ARGS will not contain --config
+    // and the preset fallback assertion below fails.
+    expect(result.stderr).toContain('"--config"')
+    const mockArgsMatch = result.stderr.match(/MOCK_ARGS: (\[.*?\])/)
+    expect(mockArgsMatch).not.toBeNull()
+    const spawnArgs: string[] = JSON.parse(mockArgsMatch![1])
+    const configFlagIdx = spawnArgs.indexOf('--config')
+    expect(configFlagIdx).toBeGreaterThanOrEqual(0)
+    expect(spawnArgs[configFlagIdx + 1]).toMatch(/retry-publish\.js$/)
   })
 })
 

--- a/tests/integration/init-flags.test.ts
+++ b/tests/integration/init-flags.test.ts
@@ -135,13 +135,13 @@ describe('Scenario A — greenfield single + --with-workflows', () => {
     expect(workflowContent).toMatch(/NODE_VERSION.*'?24'?|node-version.*24/i)
     expect(workflowContent).toContain('retry-publish-preflight')
     expect(workflowContent).toContain('OIDC')
-    // HIGH fix: publish step must use release-it directly (not release-it-preset retry-publish)
-    // to avoid CLI mismatch check when .release-it.json extends a preset config.
-    expect(workflowContent).toMatch(
+    // CLI now handles mismatch gracefully (warn + override), so the template can
+    // use the simpler native CLI form instead of the require.resolve workaround.
+    expect(workflowContent).toContain('release-it-preset retry-publish --ci')
+    expect(workflowContent).not.toMatch(
       /require\.resolve\(['"]@oorabona\/release-it-preset\/config\/retry-publish['"]\)/,
     )
-    expect(workflowContent).toContain('release-it --ci --config')
-    expect(workflowContent).not.toContain('release-it-preset retry-publish --ci')
+    expect(workflowContent).not.toContain('release-it --ci --config "$CONFIG_PATH"')
 
     // stdout confirms creation
     expect(stdout + stderr).toMatch(/Created.*release\.yml|workflow.*Created/i)


### PR DESCRIPTION
## Summary

v1.2.0 prep — relaxes the CLI's strict extends-vs-preset mismatch check, simplifies the workflow template generated by `init --with-workflows`, and dogfoods the `init` scaffolding on this repo so we consume our own preset.

## Why

The CLI used to error out when `.release-it.json` extends one preset (e.g. `default`) and the user invoked a different preset (e.g. `retry-publish`). That assumed every preset is a "shape" the project must commit to globally — but in practice operational/recovery presets like `retry-publish`, `republish`, even alternate-flow presets like `no-changelog` are most useful **on top of** an existing extended config.

Concrete consequence we hit in #52: the generated CI workflow had to bypass our own CLI with a `release-it --config $(node -e require.resolve(...))` workaround — a smell that proved the CLI was too strict.

## What changes

**Behavior:**

- CLI no longer errors on extends/preset mismatch. It warns (naming both presets and the recovery command) and uses the invoked preset's config directly via `--config <path>`. The `extends`-required check stays in place.
- Generated workflow template (`init --with-workflows`) simplifies to `pnpm exec release-it-preset retry-publish --ci` (the workaround pattern is gone).

**Dogfood (proof the feature works in production-like settings):**

- `init` runs on this very repo: creates `.release-it.json` extending `default`, adds `release:patch/minor/major/dry` scripts.
- 6 maintainer-only scripts moved to `release:dev:*` namespace (`release:dev:no-changelog`, `release:dev:retry-publish`, etc.) — clarifies "user-facing" vs "package-tester" intent for future readers.
- The dev:* scripts continue to work via the new override-with-warning behavior.

## Test plan

- [x] All 503 unit + integration tests pass (`pnpm test`)
- [x] `pnpm build` clean
- [x] Smoke: `pnpm release:dry` reaches release-it (errors only on branch guard, expected since we're on a feature branch)
- [x] Smoke: `pnpm release:dev:retry-preflight` exits 0 (utility, no mismatch check)
- [x] Smoke: invoking a mismatched preset prints the warning and uses our config
- [ ] CI green
- [ ] Senior review (opus) clean
- [ ] Copilot review clean

## Notes for reviewers

- Two commits, separated by concern: `feat(cli)` for the CLI behavior change + tests + template simplification, `chore(scripts)` for the dogfood (`.release-it.json` + script renames).
- The `release-it-preset` binary form emitted by `init`'s `SUGGESTED_SCRIPTS` was replaced locally with `node ./bin/cli.js` — the package's own bin isn't symlinked into its own `node_modules/.bin/`. End-users don't hit this; only self-referencing maintainers do.
- `release:hotfix` was kept user-facing (legitimate emergency-patch flow). Only the truly-internal alternate-changelog and recovery scripts moved to `release:dev:*`.
