### PR TITLE
fix(annotate): ignore markers inside code fences, count applied PRs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -406,7 +406,7 @@ Describe the user-visible fix.
 <!-- /changelog -->
 ```
 
-Supported block types are `added`, `changed`, `deprecated`, `removed`, `fixed`, and `security`. The command keeps unresolved bullets untouched, removes all bullets for a PR when at least one valid block is found, and regenerates those bullets under the matching Keep a Changelog section with `(#PR)` and commit links.
+Supported block types are `added`, `changed`, `deprecated`, `removed`, `fixed`, and `security`. Markers inside fenced code blocks (` ``` ` or `~~~`) are treated as documentation examples and ignored. The command keeps unresolved bullets untouched, removes all bullets for a PR when at least one valid block is found, and regenerates those bullets under the matching Keep a Changelog section with `(#PR)` and commit links.
 
 SHA-to-PR mapping uses GitHub's commit association endpoint. Squash merges are reliable; rebases, cherry-picks, or unusual merge flows may not map back to a merged PR, in which case the bullet is left unchanged. The GitHub CLI must be installed and authenticated (`gh auth status`) before running `annotate`; any `gh` failure stops the command before writing.
 

--- a/scripts/annotate-changelog.ts
+++ b/scripts/annotate-changelog.ts
@@ -500,20 +500,28 @@ function normalizeBlockText(value: string): string {
 // marker scanning never sees them while every index still maps back to the
 // original text. Grammar examples in PR bodies stay inert this way.
 function maskFencedRegions(value: string): string {
-  let fenceChar: string | null = null
+  let openFence: { char: string; length: number } | null = null
   return value
     .split('\n')
     .map(line => {
       const delimiter = line.match(/^\s{0,3}(`{3,}|~{3,})/)
-      if (fenceChar === null) {
+      if (openFence === null) {
         if (delimiter) {
-          fenceChar = delimiter[1][0]
+          openFence = { char: delimiter[1][0], length: delimiter[1].length }
           return ' '.repeat(line.length)
         }
         return line
       }
-      if (delimiter && delimiter[1][0] === fenceChar && /^\s{0,3}(`{3,}|~{3,})\s*$/.test(line)) {
-        fenceChar = null
+      // CommonMark: the closing fence must use the same character and be at
+      // least as long as the opener — a ```` fence is NOT closed by an inner
+      // ``` example, which is precisely how docs show fenced code.
+      if (
+        delimiter &&
+        delimiter[1][0] === openFence.char &&
+        delimiter[1].length >= openFence.length &&
+        /^\s{0,3}(`{3,}|~{3,})\s*$/.test(line)
+      ) {
+        openFence = null
       }
       return ' '.repeat(line.length)
     })

--- a/scripts/annotate-changelog.ts
+++ b/scripts/annotate-changelog.ts
@@ -504,7 +504,10 @@ function maskFencedRegions(value: string): string {
   return value
     .split('\n')
     .map(line => {
-      const delimiter = line.match(/^\s{0,3}(`{3,}|~{3,})/)
+      // Any indentation is accepted on purpose: fences nested under list
+      // items are indented beyond CommonMark's top-level 3-space cap, and a
+      // safety mask must over-mask rather than import a fenced example.
+      const delimiter = line.match(/^\s*(`{3,}|~{3,})/)
       if (openFence === null) {
         if (delimiter) {
           openFence = { char: delimiter[1][0], length: delimiter[1].length }
@@ -519,7 +522,7 @@ function maskFencedRegions(value: string): string {
         delimiter &&
         delimiter[1][0] === openFence.char &&
         delimiter[1].length >= openFence.length &&
-        /^\s{0,3}(`{3,}|~{3,})\s*$/.test(line)
+        /^\s*(`{3,}|~{3,})\s*$/.test(line)
       ) {
         openFence = null
       }

--- a/scripts/annotate-changelog.ts
+++ b/scripts/annotate-changelog.ts
@@ -496,6 +496,30 @@ function normalizeBlockText(value: string): string {
     .trim()
 }
 
+// Replaces fenced code regions (``` / ~~~) with spaces of identical length so
+// marker scanning never sees them while every index still maps back to the
+// original text. Grammar examples in PR bodies stay inert this way.
+function maskFencedRegions(value: string): string {
+  let fenceChar: string | null = null
+  return value
+    .split('\n')
+    .map(line => {
+      const delimiter = line.match(/^\s{0,3}(`{3,}|~{3,})/)
+      if (fenceChar === null) {
+        if (delimiter) {
+          fenceChar = delimiter[1][0]
+          return ' '.repeat(line.length)
+        }
+        return line
+      }
+      if (delimiter && delimiter[1][0] === fenceChar && /^\s{0,3}(`{3,}|~{3,})\s*$/.test(line)) {
+        fenceChar = null
+      }
+      return ' '.repeat(line.length)
+    })
+    .join('\n')
+}
+
 export function extractStructuredChangelogNotes(
   body: string | null | undefined,
   options: { prNumber?: number; warn?: (message: string) => void } = {},
@@ -506,15 +530,18 @@ export function extractStructuredChangelogNotes(
 
   const notes: ChangelogNote[] = []
   const normalizedBody = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+  // Markers are matched against the masked text (fenced regions blanked, all
+  // indices preserved); the block TEXT is sliced from the real body.
+  const scanBody = maskFencedRegions(normalizedBody)
   const openMarker = /<!--\s*changelog\s*:\s*([a-z]+)\s*-->/gi
   const closeMarker = /<!--\s*\/changelog\s*-->/i
   const prNumber = options.prNumber ?? 0
 
-  for (const match of normalizedBody.matchAll(openMarker)) {
+  for (const match of scanBody.matchAll(openMarker)) {
     const type = match[1].toLowerCase()
     const contentStart = match.index + match[0].length
-    const rest = normalizedBody.slice(contentStart)
-    const closeMatch = closeMarker.exec(rest)
+    const scanRest = scanBody.slice(contentStart)
+    const closeMatch = closeMarker.exec(scanRest)
 
     if (!closeMatch) {
       warnForPr(prNumber, options, 'unclosed marker')
@@ -527,12 +554,13 @@ export function extractStructuredChangelogNotes(
       continue
     }
 
-    const rawContent = rest.slice(0, closeMatch.index)
+    const rawContent = normalizedBody.slice(contentStart, contentStart + closeMatch.index)
     // A second open marker before the close means overlapping blocks: the
     // outer region is malformed and must never leak a raw marker (or
     // duplicated text) into the changelog. The inner block, if well-formed,
-    // is still picked up by its own matchAll iteration.
-    if (/<!--\s*changelog\s*:/i.test(rawContent)) {
+    // is still picked up by its own matchAll iteration. (Checked on the
+    // masked region too, so fenced examples inside a block stay inert.)
+    if (/<!--\s*changelog\s*:/i.test(scanRest.slice(0, closeMatch.index))) {
       warnForPr(prNumber, options, `nested changelog marker inside ${type} block`)
       continue
     }
@@ -593,7 +621,7 @@ export function renderAnnotatedBody(
   resolvedGroups: ResolvedGroup[],
   repoUrl: string,
   deps: AnnotateChangelogDeps,
-): string | null {
+): { body: string; appliedPrCount: number } | null {
   const removedEntries = new Set<ChangelogEntry>()
   const additionsBySection = new Map<string, ChangelogEntry[]>()
   let annotatedGroups = 0
@@ -668,7 +696,7 @@ export function renderAnnotatedBody(
     emitSection(heading, [], additionsBySection.get(heading) ?? [])
   }
 
-  return `\n${lines.join('\n').trim()}\n\n`
+  return { body: `\n${lines.join('\n').trim()}\n\n`, appliedPrCount: annotatedGroups }
 }
 
 function readChangelog(changelogPath: string, deps: AnnotateChangelogDeps): string {
@@ -700,14 +728,14 @@ export function annotateChangelog(deps: AnnotateChangelogDeps): void {
 
   const { repoUrl, ownerRepo } = getRequiredGitHubContext(deps)
   const resolved = resolvePullRequestGroups(groups, ownerRepo, deps)
-  const nextBody = renderAnnotatedBody(parsed, resolved.resolved, repoUrl, deps)
-  if (nextBody === null) {
+  const rendered = renderAnnotatedBody(parsed, resolved.resolved, repoUrl, deps)
+  if (rendered === null) {
     deps.log('No changelog blocks found in the resolved pull requests — nothing to annotate')
     return
   }
-  deps.writeFileSync(changelogPath, `${block.prefix}${nextBody}${block.suffix}`)
+  deps.writeFileSync(changelogPath, `${block.prefix}${rendered.body}${block.suffix}`)
 
-  deps.log(`Annotated ${resolved.resolved.length} pull request(s)`)
+  deps.log(`Annotated ${rendered.appliedPrCount} pull request(s)`)
 }
 
 /* c8 ignore start */

--- a/scripts/check-pr-status.ts
+++ b/scripts/check-pr-status.ts
@@ -14,6 +14,7 @@
 import type { ExecSyncOptions } from 'node:child_process'
 import { execSync } from 'node:child_process'
 import { appendFileSync, readFileSync } from 'node:fs'
+import { extractStructuredChangelogNotes } from './annotate-changelog.js'
 import { STRICT_CONVENTIONAL_COMMIT_REGEX } from './lib/commit-parser.js'
 import { runScript } from './lib/run-script.js'
 
@@ -40,8 +41,6 @@ export interface PrCheckDeps {
 }
 
 const SKIP_CHANGELOG_REGEX = /\[skip-changelog]/i
-const CHANGELOG_BLOCK_REGEX =
-  /<!--\s*changelog\s*:\s*(added|changed|deprecated|removed|fixed|security)\s*-->[\s\S]*?<!--\s*\/changelog\s*-->/i
 
 export function safeExec(command: string, deps: PrCheckDeps): string | null {
   try {
@@ -142,7 +141,10 @@ export function evaluateChangelogBlockStatus(deps: PrCheckDeps): ChangelogBlockS
       return 'unknown'
     }
 
-    return CHANGELOG_BLOCK_REGEX.test(body) ? 'present' : 'absent'
+    // Same parser as annotate (typed markers, fence masking): a fenced
+    // documentation example must not count as present here while annotate
+    // would ignore it.
+    return extractStructuredChangelogNotes(body).length > 0 ? 'present' : 'absent'
   } catch {
     return 'unknown'
   }

--- a/tests/unit/annotate-changelog.test.ts
+++ b/tests/unit/annotate-changelog.test.ts
@@ -59,6 +59,38 @@ across reruns.
     expect(deps.warn).toHaveBeenCalledWith(expect.stringContaining('nested changelog marker'))
   })
 
+  it('ignores changelog markers inside fenced code regions', () => {
+    // Mutation lock: without fence masking the documentation EXAMPLE block in
+    // a PR body was imported as a real entry during the v1.3.0 dogfood (#66).
+    const notes = extractStructuredChangelogNotes(
+      `
+Real entry below.
+
+<!-- changelog:added -->
+The real entry.
+<!-- /changelog -->
+
+Example for the docs:
+
+\`\`\`html
+<!-- changelog:fixed -->
+Describe the user-visible fix.
+<!-- /changelog -->
+\`\`\`
+
+~~~
+<!-- changelog:security -->
+Another inert example.
+<!-- /changelog -->
+~~~
+`,
+      { prNumber: 66, warn: deps.warn },
+    )
+
+    expect(notes).toEqual([{ section: '### Added', text: 'The real entry.' }])
+    expect(deps.warn).not.toHaveBeenCalled()
+  })
+
   it('warns and ignores unknown typed blocks', () => {
     const notes = extractStructuredChangelogNotes(
       `
@@ -273,6 +305,44 @@ Add the annotate command.
     expect(written).toContain(
       '- Add the annotate command. (#72) ([aaaaaaa](https://github.com/owner/repo/commit/aaaaaaa))',
     )
+  })
+
+  it('reports the number of PRs actually applied, not merely resolved', () => {
+    // Mutation lock: the summary used to count every resolved PR — the
+    // v1.3.0 dogfood printed "Annotated 8" while only 4 had blocks (#66).
+    vi.mocked(deps.readFileSync).mockReturnValue(`# Changelog
+
+## [Unreleased]
+
+### Added
+- with a block ([aaaaaaa](https://github.com/owner/repo/commit/aaaaaaa))
+- without a block ([dddddDD](https://github.com/owner/repo/commit/ddddddd))
+`)
+    vi.mocked(deps.execSync).mockImplementation(command => {
+      if (command === 'git config --get remote.origin.url') {
+        return 'https://github.com/owner/repo.git'
+      }
+      if (String(command).includes('commits/aaaaaaa/pulls')) {
+        return JSON.stringify([
+          {
+            number: 90,
+            merged_at: '2026-01-01T00:00:00Z',
+            body: '<!-- changelog:added -->\nWith a block.\n<!-- /changelog -->',
+          },
+        ])
+      }
+      if (String(command).includes('commits/ddddddd/pulls')) {
+        return JSON.stringify([
+          { number: 91, merged_at: '2026-01-01T00:00:00Z', body: 'no block here' },
+        ])
+      }
+      return ''
+    })
+
+    annotateChangelog(deps)
+
+    const logs = vi.mocked(deps.log).mock.calls.flat().join('\n')
+    expect(logs).toContain('Annotated 1 pull request(s)')
   })
 
   it('keeps attribution to the source PR when imported text embeds other references', () => {

--- a/tests/unit/annotate-changelog.test.ts
+++ b/tests/unit/annotate-changelog.test.ts
@@ -119,6 +119,31 @@ The real entry.
     expect(deps.warn).not.toHaveBeenCalled()
   })
 
+  it('ignores markers inside fences nested under list items', () => {
+    // Mutation lock: capping fence detection at CommonMark's top-level
+    // 3-space indent left list-nested fences (4+ spaces, a common GitHub
+    // pattern) unmasked, importing their example markers as real entries.
+    const notes = extractStructuredChangelogNotes(
+      `
+- An example nested in a list:
+
+    \`\`\`
+    <!-- changelog:fixed -->
+    Inert example under a list item.
+    <!-- /changelog -->
+    \`\`\`
+
+<!-- changelog:added -->
+The real entry.
+<!-- /changelog -->
+`,
+      { prNumber: 66, warn: deps.warn },
+    )
+
+    expect(notes).toEqual([{ section: '### Added', text: 'The real entry.' }])
+    expect(deps.warn).not.toHaveBeenCalled()
+  })
+
   it('warns and ignores unknown typed blocks', () => {
     const notes = extractStructuredChangelogNotes(
       `

--- a/tests/unit/annotate-changelog.test.ts
+++ b/tests/unit/annotate-changelog.test.ts
@@ -92,15 +92,16 @@ Another inert example.
   })
 
   it('keeps long fences open across shorter inner fence examples', () => {
-    // Mutation lock: tracking only the fence character let an inner three-
-    // backtick example close a four-backtick outer fence, re-exposing the
-    // markers that followed it inside the same code block.
+    // Mutation lock: tracking only the fence character (without the
+    // closing-length >= opener rule) lets the SINGLE unbalanced inner
+    // three-backtick line below close the four-backtick fence, re-exposing
+    // the marker that follows it inside the same code block. A paired inner
+    // fence would mask the marker by accident even under the buggy
+    // char-only tracking — the odd count is what makes this lock real.
     const notes = extractStructuredChangelogNotes(
       `
 \`\`\`\`md
-Example of a fenced example:
-\`\`\`
-some code
+How a fence opener looks:
 \`\`\`
 <!-- changelog:fixed -->
 Still inside the four-backtick fence — must stay inert.

--- a/tests/unit/annotate-changelog.test.ts
+++ b/tests/unit/annotate-changelog.test.ts
@@ -91,6 +91,33 @@ Another inert example.
     expect(deps.warn).not.toHaveBeenCalled()
   })
 
+  it('keeps long fences open across shorter inner fence examples', () => {
+    // Mutation lock: tracking only the fence character let an inner three-
+    // backtick example close a four-backtick outer fence, re-exposing the
+    // markers that followed it inside the same code block.
+    const notes = extractStructuredChangelogNotes(
+      `
+\`\`\`\`md
+Example of a fenced example:
+\`\`\`
+some code
+\`\`\`
+<!-- changelog:fixed -->
+Still inside the four-backtick fence — must stay inert.
+<!-- /changelog -->
+\`\`\`\`
+
+<!-- changelog:added -->
+The real entry.
+<!-- /changelog -->
+`,
+      { prNumber: 66, warn: deps.warn },
+    )
+
+    expect(notes).toEqual([{ section: '### Added', text: 'The real entry.' }])
+    expect(deps.warn).not.toHaveBeenCalled()
+  })
+
   it('warns and ignores unknown typed blocks', () => {
     const notes = extractStructuredChangelogNotes(
       `

--- a/tests/unit/check-pr-status.test.ts
+++ b/tests/unit/check-pr-status.test.ts
@@ -91,6 +91,25 @@ describe('check-pr-status utilities', () => {
     }
   })
 
+  it('reports changelog block absent when the only block is a fenced example', () => {
+    // Mutation lock: the previous raw regex counted a documentation example
+    // inside a code fence as present while annotate ignores it (#66) —
+    // check-pr and annotate must share the same parser.
+    const event = writeTempEvent(
+      JSON.stringify({
+        pull_request: {
+          body: 'Example:\n\n```html\n<!-- changelog:fixed -->\nDescribe the fix.\n<!-- /changelog -->\n```\n',
+        },
+      }),
+    )
+
+    try {
+      expect(evaluateChangelogBlockStatus(createBlockDeps(event.path))).toBe('absent')
+    } finally {
+      rmSync(event.dir, { recursive: true, force: true })
+    }
+  })
+
   it('reports changelog block absent when the PR body has no typed block', () => {
     const event = writeTempEvent(JSON.stringify({ pull_request: { body: 'Plain PR body' } }))
 


### PR DESCRIPTION
## Summary

Closes #66 — both polish items surfaced by the v1.3.0 dogfood, plus the coherence work they pulled in.

- **Fence-aware marker scanning**: changelog markers inside fenced code regions are inert. Scanning runs over a masked copy of the body (fenced lines blanked, indices preserved, block text still sliced from the real body), honoring CommonMark fence semantics — same character AND closing length ≥ opener, so a ```` fence containing a ``` example stays closed to markers throughout.
- **`check-pr` shares the same parser**: the `changelog_block` output now goes through `extractStructuredChangelogNotes` instead of a raw regex, so a fenced documentation example can never report `present` while `annotate` would ignore it.
- **Honest summary count**: `Annotated N pull request(s)` reports PRs whose blocks were actually applied, not every PR that merely resolved.

## Verification

- 580 tests pass (27 files), zero skipped — new locks: fenced example inert (backtick + tilde), long-fence-with-inner-example stays masked, fenced-example body reports `absent` in check-pr, applied-vs-resolved count.
- The exact v1.3.0 dogfood scenario (documentation example block inside the PR body's code fence) is the regression fixture.

Closes #66