### PR TITLE
feat(ci): SLSA Build L3 provenance and cosign attestations (#50)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ name: Publish Package
 # (workflow_dispatch). Uses npm OIDC trusted publishing — no NPM_TOKEN needed.
 # Configure the OIDC trusted publisher on npmjs against this workflow path
 # (.github/workflows/publish.yml).
+# Canonical manual replay for attestations: gh workflow run publish.yml --ref vX.Y.Z (tag ref required).
+# workflow_call callers must grant actions: read for the nested SLSA generator.
 
 on:
   push:
@@ -50,6 +52,10 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  group: publish-${{ inputs.tag || github.ref_name }}
+  cancel-in-progress: false
 
 env:
   NODE_VERSION: '24'  # npm >= 11.5.1 ships with Node 24, required for OIDC trusted publishing
@@ -197,3 +203,154 @@ jobs:
           else
             echo "**Scope**: npm + GitHub release" >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  attest-hash:
+    runs-on: ubuntu-latest
+    needs: publish
+    if: ${{ !inputs.npm_only && needs.publish.result == 'success' && github.ref == format('refs/tags/{0}', inputs.tag || github.ref_name) }}
+    permissions:
+      contents: read
+    outputs:
+      hashes: ${{ steps.pack.outputs.hashes }}
+      tgz: ${{ steps.pack.outputs.tgz }}
+      pkg: ${{ steps.pack.outputs.pkg }}
+      version: ${{ steps.pack.outputs.version }}
+      should_attest: ${{ steps.pack.outputs.should_attest }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Download registry tarball and hash subject
+        id: pack
+        env:
+          GITHUB_ONLY: ${{ inputs.github_only }}
+        run: |
+          set -euo pipefail
+
+          PKG="$(jq -r .name package.json)"
+          VER="$(jq -r .version package.json)"
+          VER="${VER#v}"
+
+          if [ "${GITHUB_ONLY}" = "true" ] && ! npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
+            echo "::notice::github_only run and ${PKG}@${VER} is not on npm — skipping attestation; heal with a full replay on the tag ref once npm has the version"
+            echo "should_attest=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          BASENAME="${PKG#@}"
+          BASENAME="${BASENAME//\//-}"
+          TGZ="${BASENAME}-${VER}.tgz"
+          PACK_DIR="${RUNNER_TEMP}/npm-pack-subject"
+
+          rm -rf "${PACK_DIR}"
+          mkdir -p "${PACK_DIR}"
+          cd "${PACK_DIR}"
+
+          for attempt in 1 2 3 4 5; do
+            rm -f "${TGZ}"
+            if npm pack "${PKG}@${VER}" > npm-pack.log 2>&1 && [ -f "${TGZ}" ]; then
+              break
+            fi
+
+            if [ "${attempt}" -eq 5 ]; then
+              echo "::error::npm pack did not produce ${TGZ} after 5 attempts"
+              cat npm-pack.log >&2 || true
+              exit 1
+            fi
+
+            sleep 12
+          done
+
+          cd "${GITHUB_WORKSPACE}"
+          REGISTRY_GITHEAD="$(npm view "${PKG}@${VER}" gitHead 2>/dev/null || true)"
+          HEAD_SHA="$(git rev-parse HEAD)"
+          if [ -z "${REGISTRY_GITHEAD}" ] || [ "${REGISTRY_GITHEAD}" != "${HEAD_SHA}" ]; then
+            echo "::error::Refusing to attest: registry ${PKG}@${VER} gitHead (${REGISTRY_GITHEAD:-absent}) does not match the attested ref commit (${HEAD_SHA}). The published bytes were not built from this tag."
+            exit 1
+          fi
+          cd "${PACK_DIR}"
+
+          {
+            echo "pkg=${PKG}"
+            echo "version=${VER}"
+            echo "tgz=${TGZ}"
+            echo "hashes=$(sha256sum "${TGZ}" | base64 -w0)"
+            echo "should_attest=true"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Upload registry tarball artifact
+        if: steps.pack.outputs.should_attest == 'true'
+        uses: actions/upload-artifact@v8
+        with:
+          name: registry-tarball
+          path: ${{ runner.temp }}/npm-pack-subject/${{ steps.pack.outputs.tgz }}
+          if-no-files-found: error
+
+  provenance:
+    needs: [publish, attest-hash]
+    if: ${{ !inputs.npm_only && needs.publish.result == 'success' && needs.attest-hash.result == 'success' && needs.attest-hash.outputs.should_attest == 'true' && github.ref == format('refs/tags/{0}', inputs.tag || github.ref_name) }}
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.attest-hash.outputs.hashes }}
+      provenance-name: ${{ needs.attest-hash.outputs.tgz }}.intoto.jsonl
+      upload-assets: false
+
+  attach-attestations:
+    runs-on: ubuntu-latest
+    needs: [publish, attest-hash, provenance]
+    if: ${{ !inputs.npm_only && needs.publish.result == 'success' && needs.attest-hash.result == 'success' && needs.attest-hash.outputs.should_attest == 'true' && needs.provenance.result == 'success' && github.ref == format('refs/tags/{0}', inputs.tag || github.ref_name) }}
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download registry tarball
+        uses: actions/download-artifact@v8
+        with:
+          name: registry-tarball
+          path: release-assets
+
+      - name: Download provenance artifact
+        uses: actions/download-artifact@v8
+        with:
+          path: provenance
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign and upload release assets
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+          TGZ: ${{ needs.attest-hash.outputs.tgz }}
+          GH_REPO: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          cd release-assets
+
+          if [ ! -f "${TGZ}" ]; then
+            echo "::error::Expected registry tarball ${TGZ} was not downloaded"
+            exit 1
+          fi
+
+          PROVENANCE="$(find "${GITHUB_WORKSPACE}/provenance" -type f -name "${TGZ}.intoto.jsonl" -print -quit)"
+          if [ -z "${PROVENANCE}" ]; then
+            echo "::error::Expected provenance ${TGZ}.intoto.jsonl was not downloaded"
+            find "${GITHUB_WORKSPACE}/provenance" -type f -print >&2 || true
+            exit 1
+          fi
+          cp "${PROVENANCE}" "${TGZ}.intoto.jsonl"
+
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "::error::GitHub release ${TAG} was not found; refusing to upload attestations"
+            exit 1
+          fi
+
+          cosign sign-blob --yes --bundle "${TGZ}.sigstore.json" "${TGZ}"
+          gh release upload "${TAG}" "${TGZ}" "${TGZ}.intoto.jsonl" "${TGZ}.sigstore.json" --clobber

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,7 +347,7 @@ Extends mode:
 
 5. **publish.yml** - Unified GitHub Release + npm Publish
    - Triggered on tag push (`v*`), `workflow_call`, or `workflow_dispatch`
-   - Manual replay: `gh workflow run publish.yml --ref main -f tag=vX.Y.Z`
+   - Manual replay: `gh workflow run publish.yml --ref vX.Y.Z`
    - Optional `npm_only` / `github_only` inputs scope a partial replay
    - Uses npm OIDC trusted publishing — no `NPM_TOKEN` secret needed
    - Runs `release-it-preset retry-publish-preflight` then `retry-publish --ci`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Shareable [release-it](https://github.com/release-it/release-it) configuration a
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node](https://img.shields.io/node/v/@oorabona/release-it-preset.svg)](https://nodejs.org/)
 [![OIDC trusted publishing](https://img.shields.io/badge/npm-OIDC%20trusted%20publishing-green.svg)](https://docs.npmjs.com/trusted-publishers)
+[![SLSA Level 3](https://slsa.dev/images/gh-badge-level3.svg)](docs/VERIFY.md)
 [![CI](https://github.com/oorabona/release-it-preset/actions/workflows/ci.yml/badge.svg)](https://github.com/oorabona/release-it-preset/actions/workflows/ci.yml)
 [![Audit](https://github.com/oorabona/release-it-preset/actions/workflows/audit.yml/badge.svg)](https://github.com/oorabona/release-it-preset/actions/workflows/audit.yml)
 [![codecov](https://codecov.io/github/oorabona/release-it-preset/graph/badge.svg?token=6RMN34Z7TX)](https://codecov.io/github/oorabona/release-it-preset)
@@ -36,6 +37,13 @@ pnpm release:minor                 # bump + commit + tag + push (CI publishes)
 **One-off (no install):** `pnpm dlx @oorabona/release-it-preset init --with-workflows`
 
 → Full reference: [docs/USAGE.md](docs/USAGE.md) · [Migration v0→v1](docs/MIGRATION.md) · [Public API](docs/PUBLIC_API.md)
+
+## Supply chain verification
+
+Releases use npm OIDC provenance and, starting with v1.4.0, attach the npm
+registry tarball, SLSA L3 provenance, and a cosign keyless bundle to the GitHub
+release. See [docs/VERIFY.md](docs/VERIFY.md) for copy-paste verification
+commands.
 
 ## Why this preset?
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -789,6 +789,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read  # Required by the nested SLSA generator.
 
 jobs:
   publish:
@@ -840,8 +841,11 @@ Triggered on tag push (`v*`), `workflow_call`, or `workflow_dispatch`. Optional 
 
 **Manual replay:**
 ```bash
-gh workflow run publish.yml --ref main -f tag=vX.Y.Z
+gh workflow run publish.yml --ref vX.Y.Z
 ```
+
+Dispatching on the tag ref keeps SLSA provenance and cosign certificate
+identities tag-canonical (`@refs/tags/vX.Y.Z`).
 
 ---
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -1,0 +1,103 @@
+# Verifying Release Artifacts
+
+This guide verifies a release of `@oorabona/release-it-preset`. Replace
+`X.Y.Z` with the version and `vX.Y.Z` with the matching tag. For the first
+release containing this chain, use `1.4.0` and `v1.4.0`.
+
+Set the expected tarball name:
+
+```bash
+TGZ="oorabona-release-it-preset-X.Y.Z.tgz"
+```
+
+## 1. What You Can Verify
+
+| Check | Artifact | Trust model |
+|-------|----------|-------------|
+| npm provenance | Installed npm package | npm registry provenance binds the package to the publishing GitHub Actions workflow (SLSA L2). |
+| SLSA provenance | GitHub release `.intoto.jsonl` | The SLSA generic generator signs provenance from an isolated trusted-builder workflow (SLSA L3). |
+| cosign signature | GitHub release `.sigstore.json` | Fulcio/Rekor keyless signing binds the tarball to `publish.yml` on the release tag. |
+
+## 2. npm Provenance (L2)
+
+`npm audit signatures` verifies an installed dependency tree, so run it in a
+temporary project:
+
+```bash
+tmp="$(mktemp -d)"
+cd "${tmp}"
+npm init -y
+npm install @oorabona/release-it-preset@X.Y.Z
+npm audit signatures
+```
+
+## 3. SLSA L3 Provenance
+
+Download the release tarball and attestations:
+
+```bash
+mkdir "release-it-preset-X.Y.Z-verify"
+cd "release-it-preset-X.Y.Z-verify"
+gh release download vX.Y.Z --repo oorabona/release-it-preset --pattern '*.tgz' --pattern '*.intoto.jsonl' --pattern '*.sigstore.json'
+TGZ="oorabona-release-it-preset-X.Y.Z.tgz"
+```
+
+Verify the SLSA provenance:
+
+```bash
+slsa-verifier verify-artifact "${TGZ}" --provenance-path "${TGZ}.intoto.jsonl" --source-uri github.com/oorabona/release-it-preset --source-tag vX.Y.Z
+```
+
+Use `slsa-verifier` v2.7.1 for this command.
+
+## 4. cosign Keyless Signature
+
+Verify the cosign bundle:
+
+```bash
+cosign verify-blob "${TGZ}" --bundle "${TGZ}.sigstore.json" --certificate-identity="https://github.com/oorabona/release-it-preset/.github/workflows/publish.yml@refs/tags/vX.Y.Z" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+```
+
+This works from the downloaded assets and does not require a GitHub account.
+
+## 5. Binding the Release Asset to npm
+
+Fetch the tarball npm serves into a separate directory. `--pack-destination`
+is important because `npm pack` would otherwise use the same basename as the
+downloaded release asset.
+
+```bash
+mkdir npm-copy
+npm pack @oorabona/release-it-preset@X.Y.Z --pack-destination ./npm-copy/
+test "$(sha256sum "${TGZ}" | awk '{print $1}')" = "$(sha256sum "./npm-copy/${TGZ}" | awk '{print $1}')"
+```
+
+The full trust chain is two-layered: npm provenance verifies the registry
+package's source and publish workflow, while the SLSA L3 and cosign assets
+verify that the GitHub release tarball is the same registry byte stream signed
+by the tag-canonical release workflow. Before signing, the release workflow
+additionally verifies that the registry package's `gitHead` matches the tag's
+commit, so attestations are never produced for bytes built from another ref.
+
+## 6. Caveats
+
+- Do not rename the downloaded `.tgz` before running `slsa-verifier`; the
+  provenance subject is matched by tarball basename.
+- Attestation assets are only produced by runs on the tag ref itself.
+  Branch replays with `-f tag=vX.Y.Z` from another ref can republish npm and
+  GitHub release content, but they never (re)write attestation assets, so
+  existing canonical assets cannot be downgraded.
+- Releases before `v1.4.0` have npm provenance only. They do not carry the SLSA
+  L3 provenance or cosign release assets described here.
+
+## 7. Pinned Tool Versions
+
+These versions are the expected verification and generation pins for this
+attestation chain:
+
+- `slsa-verifier` v2.7.1
+- cosign CLI v3.x
+- `slsa-framework/slsa-github-generator` generic generator v2.1.0
+
+When one of these drifts, update this document and
+[ADR 0007](adr/0007-slsa-generic-generator-cosign.md) together.

--- a/docs/adr/0007-slsa-generic-generator-cosign.md
+++ b/docs/adr/0007-slsa-generic-generator-cosign.md
@@ -1,0 +1,78 @@
+# ADR-0007: SLSA generic generator plus cosign release attestations
+
+## Status
+
+Accepted (2026-06-11).
+
+## Context
+
+Issue #50 requires each release to attach verifiable SLSA L3 provenance and a
+Sigstore signature for the exact tarball npm serves, without changing the
+existing release-it driven npm publish or adding repository secrets.
+
+The initially proposed slsa-github-generator Node.js builder does not fit this
+package. It does not support pnpm and it takes over the build and publish flow,
+which would replace the existing `release-it-preset retry-publish --ci` path
+and risk changing npm provenance behavior.
+
+GitHub Artifact Attestations were also evaluated. They are improving quickly,
+but the L3 claim depends on splitting the signing work into a reusable workflow,
+and the result is not verifiable by `slsa-verifier` against the
+slsa-github-generator trusted-builder identity.
+
+## Decision
+
+Use the slsa-github-generator generic SLSA3 reusable workflow
+(`generator_generic_slsa3.yml@v2.1.0`) to attest the registry tarball after npm
+publish completes, and use cosign keyless signing to produce a Sigstore bundle
+for the same bytes.
+
+The release chain is:
+
+1. Publish with the existing release-it retry-publish flow and npm OIDC
+   provenance.
+2. Download the just-published tarball from the npm registry with `npm pack`
+   and verify the registry `gitHead` matches the tag commit before attesting.
+3. Generate SLSA L3 provenance for that tarball with the generic generator.
+4. Sign the same tarball with cosign keyless signing.
+5. Attach the tarball, provenance, and Sigstore bundle to the GitHub release.
+
+The generator remains tag-pinned to `v2.1.0` because the SLSA trusted-builder
+protocol depends on that identity.
+
+## Consequences
+
+- **Positive**: The npm publish path remains unchanged, preserving npm OIDC
+  trusted publishing and existing release-it behavior.
+- **Positive**: Consumers can verify the L3 provenance with `slsa-verifier` and
+  the signature with the cosign CLI using only GitHub release assets.
+- **Positive**: The attested subject is the exact registry tarball, not a local
+  rebuild that could drift from npm's served bytes.
+- **Negative**: Release runs gain post-publish jobs and depend on npm registry
+  propagation before attestations can be generated.
+- **Negative**: The release trust story has two layers: npm provenance binds the
+  registry package to source, while SLSA L3 and cosign bind the release asset to
+  the registry bytes.
+
+## Alternatives considered
+
+- **slsa-github-generator Node.js builder**: rejected because it does not
+  support pnpm and would take over build and npm publish.
+- **GitHub Artifact Attestations only**: rejected for now because the L3 posture
+  depends on an additional reusable-workflow split and is not
+  `slsa-verifier`-verifiable through the slsa-github-generator trusted builder.
+- **cosign only**: rejected because a signature proves the workflow identity for
+  the tarball but does not provide SLSA L3 provenance.
+- **npm provenance only**: rejected because npm provenance is SLSA L2 and does
+  not produce the requested GitHub release attestation assets.
+
+## Migration trigger
+
+Re-evaluate GitHub Artifact Attestations when either condition becomes true:
+
+1. `slsa-github-generator` publishes a deprecation notice.
+2. The OSSF revamp ships a GA replacement for the generic generator.
+
+At that point, compare GitHub Artifact Attestations against the current
+`slsa-verifier` workflow and migrate only if consumers retain copy-pasteable
+verification for release tarballs.


### PR DESCRIPTION
Closes #50

## Summary

Every release now ships verifiable supply-chain artifacts on the GitHub release, alongside the existing npm OIDC provenance (which is unchanged):

- `attest-hash` downloads the just-published tarball from the npm registry (retry-tolerant), verifies the registry `gitHead` matches the tag commit (fail-closed — attestations can never cover bytes built from another ref), and hashes it as the attestation subject
- `provenance` generates SLSA Build L3 provenance via the isolated `slsa-framework/slsa-github-generator` generic builder (`@v2.1.0`)
- `attach-attestations` signs the tarball with cosign keyless (`--bundle`) and attaches tarball + `.intoto.jsonl` + `.sigstore.json` to the release (`--clobber` for idempotent replays)

The chain only runs on the tag ref itself (`github.ref == refs/tags/<tag>`): branch replays can republish npm/GitHub content but can never write or downgrade attestation assets. `github_only` replays of versions absent from npm skip attestation gracefully. No new secrets — everything flows from the job-scoped OIDC token.

`docs/VERIFY.md` gives consumers copy-pasteable verification: `npm audit signatures` (L2), `slsa-verifier verify-artifact` (L3), `cosign verify-blob` (offline, no GitHub account), plus the sha256 binding between the npm tarball and release assets. ADR 0007 records the architecture choice and its concrete migration trigger. Canonical manual replay becomes `gh workflow run publish.yml --ref vX.Y.Z` so attestation identities stay tag-canonical.

<!-- changelog:added -->
SLSA Build L3 provenance and cosign keyless signature attached to every GitHub release; see docs/VERIFY.md for copy-pasteable verification commands ([#50](https://github.com/oorabona/release-it-preset/issues/50))
<!-- /changelog -->

<!-- changelog:changed -->
Canonical manual replay of publish.yml is now `gh workflow run publish.yml --ref vX.Y.Z` (tag ref), keeping SLSA and cosign identities tag-canonical
<!-- /changelog -->

## Verification

- 581 tests passing, zero skipped (`pnpm test --run`)
- `actionlint` clean on `publish.yml` (only the pre-existing SC2129 style note, also present on main)
- `release-it-preset doctor` npm-provenance-readiness unaffected (the three new jobs are not publishing jobs)
- The `publish` job block is byte-identical to main — existing npm provenance behavior untouched
- End-to-end proof lands with the v1.4.0 release: every `docs/VERIFY.md` command will be run verbatim against it
- `sigstore/cosign-installer` SHA-pin independently verified against `refs/tags/v4.1.2`

## Test plan

- [ ] CI passes (lint, typecheck, tests)
- [ ] v1.4.0 release run produces the three assets and all VERIFY.md commands pass
